### PR TITLE
Allow classes on <th> and <td> elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ For each `table-column` a column will be rendered. It can have these props:
 - `filterable`: if this is set to `false` than this column won't be used when filtering
 - `filter-on`: you can set this to any property present in `data`. When filtering the column that property will be used to filter on instead of the property in `show`.
 - `hidden`: if you set this to `true` then the column will be hidden. This is useful when you want to sort by a field but don't want it to be visible.
+- `header-class`: the passed value will be added to the `class` attribute of the columns `th` element.
+- `cell-class`: the passed value will be added to the `class` attribute of the columns `td` element.
 
 ### Modifying the used texts and classes
 

--- a/src/classes/Column.js
+++ b/src/classes/Column.js
@@ -4,7 +4,7 @@ export default class Column {
     constructor(columnComponent) {
         const properties = pick(columnComponent, [
             'show', 'label', 'dataType', 'sortable', 'sortBy', 'filterable',
-            'filterOn', 'hidden', 'formatter',
+            'filterOn', 'hidden', 'formatter', 'cellClass', 'headerClass',
         ]);
 
         for (const property in properties) {

--- a/src/components/TableColumn.vue
+++ b/src/components/TableColumn.vue
@@ -18,6 +18,9 @@
             formatter: { default: v => v, type: Function },
 
             hidden: { default: false, type: Boolean },
+
+            cellClass: { default: null, type: String },
+            headerClass: { default: null, type: String },
         },
     };
 </script>

--- a/src/components/TableColumnHeader.vue
+++ b/src/components/TableColumnHeader.vue
@@ -39,14 +39,16 @@
 
             headerClass() {
                 if (! this.column.isSortable()) {
-                    return;
+                    return this.column.properties.headerClass;
                 }
+
+                let userHeaderClass = this.column.properties.headerClass ? ' '+this.column.properties.headerClass : '';
 
                 if (this.column.properties.show !== this.sort.fieldName) {
-                    return 'table-component__th--sort';
+                    return 'table-component__th--sort'+userHeaderClass;
                 }
 
-                return `table-component__th--sort-${this.sort.order}`;
+                return `table-component__th--sort-${this.sort.order}`+userHeaderClass;
             },
 
             isVisible() {

--- a/src/components/TableColumnHeader.vue
+++ b/src/components/TableColumnHeader.vue
@@ -42,7 +42,9 @@
                     return this.column.properties.headerClass;
                 }
 
-                let userHeaderClass = this.column.properties.headerClass ? ' '+this.column.properties.headerClass : '';
+                let userHeaderClass = this.column.properties.headerClass ?
+                    ' '+this.column.properties.headerClass :
+                    '';
 
                 if (this.column.properties.show !== this.sort.fieldName) {
                     return 'table-component__th--sort'+userHeaderClass;

--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -114,7 +114,7 @@
             this.columns = this.$slots.default
                 .filter(column => column.componentInstance)
                 .map(column => pick(column.componentInstance, [
-                    'show', 'label', 'dataType', 'sortable', 'sortBy', 'filterable', 'filterOn', 'hidden',  'formatter',
+                    'show', 'label', 'dataType', 'sortable', 'sortBy', 'filterable', 'filterOn', 'hidden',  'formatter', 'cellClass', 'headerClass'
                 ]))
                 .map(columnProperties => new Column(columnProperties));
 

--- a/src/components/TableRow.vue
+++ b/src/components/TableRow.vue
@@ -1,6 +1,6 @@
 <template>
     <tr>
-        <td v-for="column in visibleColumns" v-html="getValue(column)"></td>
+        <td v-for="column in visibleColumns" v-html="getValue(column)" :class="column.properties.cellClass"></td>
     </tr>
 </template>
 


### PR DESCRIPTION
This PR enables classes to be added to `th` and `td` elements of the table like so...

```html
<table-column
    show="income"
    label="Income"
    header-class="is-primary"
    cell-class="has-right-text">
</table-column>
```

I'm working with a table where I need columns that contain numbers right justified. Instead of doing an nth child css selector, which I'll have to update if I ever change my column order, I can now just apply class to that column.

I think it would also be handy to be able to specify different classes for the header cell, thus I've added a seperate property for that.

I'm new to Vue and fumbled my way through working out how to do this, so please let me know any corrections if this is of interest to the project.