### PR TITLE
Allow custom classes on filter input

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can pass these props to `table-component`:
 - `cache-id`: if you use multiple instances of `table-component` on the same page you must set this to a unique value per instance.
 - `table-class`: the passed value will be added to the `class` attribute of the rendered table
 - `filter-placeholder`: the text used as a placeholder in the filter field
+- `filter-input-class`: additional classes that you will be applied to the filter text input
 - `filter-no-results`: the text displayed when the filtering returns no results
 
 For each `table-column` a column will be rendered. It can have these props:

--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -3,7 +3,7 @@
 
         <div v-if="showFilter" class="table-component__filter">
             <input
-                class="table-component__filter__field"
+                :class="fullFilterInputClass"
                 type="text"
                 v-model="filter"
                 :placeholder="filterPlaceholder"
@@ -86,6 +86,7 @@
             cacheLifetime: { default: 5 },
 
             tableClass: { default: settings.tableClass },
+            filterInputClass: { default: null, type: String },
             filterPlaceholder: { default: settings.filterPlaceholder },
             filterNoResults: { default: settings.filterNoResults },
         },
@@ -144,6 +145,12 @@
                     [this.tableClass];
 
                 return ['table-component__table', ...extraClasses];
+            },
+
+            fullFilterInputClass() {
+                return this.filterInputClass ?
+                    'table-component__filter__field '+this.filterInputClass :
+                    'table-component__filter__field';
             },
 
             ariaCaption() {


### PR DESCRIPTION
This is similar to #30 and allows custom classes to be added to the filter text input.

```html
<table-component
    ...
    filter-placeholder="Filter"
    filter-input-class="input"
    filter-no-results="No matches for your search criteria"
    ...
>
```

I figure a pretty common scenario is that a dev is using a framework that provides classes to style text inputs i.e. [Bulma's](http://bulma.io/documentation/form/general/) `.input` selector.

This means we don't need to re-apply all these styles to the built in filter class `.table-component__filter__field`.