### PR TITLE
Fix filter to skips when all filterables are false

### DIFF
--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -162,6 +162,14 @@
                     return this.sortedRows;
                 }
 
+                if (!this.showFilter) {
+                    return this.sortedRows;
+                }
+
+                if (!this.columns.filter(column => column.isFilterable()).length) {
+                    return this.sortedRows;
+                }
+
                 return this.sortedRows.filter(row => row.passesFilter(this.filter));
             },
 


### PR DESCRIPTION
Avoid showing filter-no-results when every filterable of table-column is false