### PR TITLE
Change columnProperties to rowProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Alternatively you can pass a function to the `formatter` prop. Here's an example
 <script>
 export default {
     methods: {
-        formatter(value, columnProperties) {
+        formatter(value, rowProperties) {
             return `Hi, I am ${value}`;    
         },
     },


### PR DESCRIPTION
I think the second parameter of the formatter functions contain details (/ data) about the row instead of the column.