### PR TITLE
Add slot support for footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to `vue-table-component` will be documented in this file
 
+## 1.7.0 - 2017-10-26
+- Added named slot `tfoot` to display table footer information, receives row data as scoped properties
+
 ## 1.6.1 - 2017-09-25
 - Fixed a bug that didn't rerender the table when a column was changed
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Alternatively you can pass a function to the `formatter` prop. Here's an example
 export default {
     methods: {
         formatter(value, rowProperties) {
-            return `Hi, I am ${value}`;    
+            return `Hi, I am ${value}`;
         },
     },
 }
@@ -234,6 +234,63 @@ export default {
 ```
 
 This will display values `Hi, I am John` and `Hi, I am Paul`.
+
+## Adding table footer `<tfoot>` information
+
+Sometimes it can be useful to add information to the bottom of the table like summary data.
+A slot named `tfoot` is available and it receives all of the `rows` data to do calculations on the fly or you can show data directly from whatever is available in the parent scope.
+
+```html
+<table-component
+    :data="[{ firstName: 'John', songs: 72 },{ firstName: 'Paul', songs: 70 }]">
+    <table-column show="firstName" label="First name"></table-column>
+    <table-column show="songs" label="Songs" data-type="numeric"></table-column>
+    <template slot="tfoot" scope="{ rows }">
+        <tr>
+            <th>Total Songs:</th>
+            <th>{{ rows.reduce((sum, value) => { return sum + value.data.songs; }, 0) }}</th>
+            <th>&nbsp;</th>
+            <th>&nbsp;</th>
+        </tr>
+    </template>
+</table-component>
+```
+
+OR  
+
+```vue
+<template>
+    <table-component
+        :data="tableData">
+        <table-column show="firstName" label="First name"></table-column>
+        <table-column show="songs" label="Songs" data-type="numeric"></table-column>
+        <template slot="tfoot">
+            <tr>
+                <th>Total Songs:</th>
+                <th>{{ totalSongs }}</th>
+            </tr>
+        </template>
+    </table-component>
+</template>
+<script>
+export default {
+    computed: {
+        totalSongs () {
+            return this.tableData.reduce(sum, value => {
+                return sum + value.songs;
+            }, 0);
+        }
+    },
+    data () {
+        return {
+            tableData: [{ firstName: 'John', songs: 72 },{ firstName: 'Paul', songs: 70 }]
+        }
+    }
+}
+</script>
+```
+
+Note: `rows` slot scope data includes more information gathered by the Table Component (e.g. `columns`) and `rows.data` is where the original `data` information is located.
 
 ## Changelog
 

--- a/__tests__/components/table-component/TableComponent.test.js
+++ b/__tests__/components/table-component/TableComponent.test.js
@@ -84,6 +84,27 @@ describe('TableComponent', () => {
         expect(document.body.innerHTML).toMatchSnapshot();
     });
 
+    it('supports a named slot to display a tfoot section', async () => {
+        document.body.innerHTML = `
+            <div id="app">
+                <table-component
+                    :data="[{ firstName: 'John' },{ firstName: 'Paul' }]">
+                    <table-column show="firstName" label="First name"></table-column>
+                    <template slot="tfoot">
+                        <tr>
+                            <td>Name count:</td>
+                            <td>2</td>
+                        </tr>
+                    </template>
+                </table-component>
+            </div>
+        `;
+
+        await createVm();
+
+        expect(document.body.innerHTML).toMatchSnapshot();
+    });
+
     it('has an prop to disable the filter', async () => {
         document.body.innerHTML = `
             <div id="app">
@@ -189,7 +210,7 @@ describe('TableComponent', () => {
     it('can accept a function to fetch the data', async () => {
         const serverResponse = () => {
             return {
-                data: [{firstName: 'John'}, {id: 2, firstName: 'Paul'}],
+                data: [{ firstName: 'John' }, { id: 2, firstName: 'Paul' }],
             };
         };
 
@@ -213,7 +234,7 @@ describe('TableComponent', () => {
     it('can render pagination when the server responds with pagination data', async () => {
         const serverResponse = () => {
             return {
-                data: [{firstName: 'John'}, {id: 2, firstName: 'Paul'}],
+                data: [{ firstName: 'John' }, { id: 2, firstName: 'Paul' }],
 
                 pagination: {
                     totalPages: 4,
@@ -240,9 +261,9 @@ describe('TableComponent', () => {
     });
 
     it('clicking a link in the pagination will rerender the table', async () => {
-        const serverResponse = ({page}) => {
+        const serverResponse = ({ page }) => {
             return {
-                data: [{firstName: `John ${page}`}, {id: 2, firstName: `Paul ${page}`}],
+                data: [{ firstName: `John ${page}` }, { id: 2, firstName: `Paul ${page}` }],
 
                 pagination: {
                     totalPages: 4,

--- a/__tests__/components/table-component/TableComponent.test.js
+++ b/__tests__/components/table-component/TableComponent.test.js
@@ -90,10 +90,10 @@ describe('TableComponent', () => {
                 <table-component
                     :data="[{ firstName: 'John' },{ firstName: 'Paul' }]">
                     <table-column show="firstName" label="First name"></table-column>
-                    <template slot="tfoot">
+                    <template slot="tfoot" scope="{ rows }">
                         <tr>
                             <td>Name count:</td>
-                            <td>2</td>
+                            <td>{{ rows.length }}</td>
                         </tr>
                     </template>
                 </table-component>

--- a/__tests__/components/table-component/__snapshots__/TableComponent.test.js.snap
+++ b/__tests__/components/table-component/__snapshots__/TableComponent.test.js.snap
@@ -48,6 +48,8 @@ exports[`TableComponent accepts a function to format values 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -102,6 +104,8 @@ exports[`TableComponent can accept a function to fetch the data 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -156,6 +160,8 @@ exports[`TableComponent can add extra classes to the table, the cells and the he
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -204,6 +210,8 @@ exports[`TableComponent can display a custom message when filtering results in n
         </thead>
         <tbody class="table-component__table__body">
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <div class="table-component__message">
@@ -254,6 +262,8 @@ exports[`TableComponent can display a custom placeholder in the filter field 1`]
         </thead>
         <tbody class="table-component__table__body">
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <div class="table-component__message">
@@ -310,6 +320,8 @@ exports[`TableComponent can display nested properties 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -364,6 +376,8 @@ exports[`TableComponent can mount 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -418,6 +432,8 @@ exports[`TableComponent can render pagination when the server responds with pagi
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -495,6 +511,8 @@ exports[`TableComponent can update columns 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -549,6 +567,8 @@ exports[`TableComponent can update columns 2`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -603,6 +623,8 @@ exports[`TableComponent clicking a link in the pagination will rerender the tabl
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -680,6 +702,8 @@ exports[`TableComponent clicking a link in the pagination will rerender the tabl
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -752,6 +776,8 @@ exports[`TableComponent has an prop to disable the caption 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -800,6 +826,72 @@ exports[`TableComponent has an prop to disable the filter 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
+      </table>
+    </div>
+    <!---->
+    <div style="display: none;">
+      <!---->
+    </div>
+    <!---->
+  </div>
+</div>
+
+`;
+
+exports[`TableComponent supports a named slot to display a tfoot section 1`] = `
+
+<div id="app">
+  <div class="table-component">
+    <div class="table-component__filter">
+      <input type="text"
+             placeholder="Filter table…"
+             class="table-component__filter__field"
+      >
+      <!---->
+    </div>
+    <div class="table-component__table-wrapper">
+      <table class="table-component__table">
+        <caption role="alert"
+                 aria-live="polite"
+                 class="table-component__table__caption"
+        >
+          Table not sorted
+        </caption>
+        <thead class="table-component__table__head">
+          <tr>
+            <th role="columnheader"
+                scope="col"
+                aria-sort="none"
+                class="table-component__th table-component__th--sort"
+            >
+              First name
+            </th>
+          </tr>
+        </thead>
+        <tbody class="table-component__table__body">
+          <tr>
+            <td>
+              John
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Paul
+            </td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>
+              Name count:
+            </td>
+            <td>
+              2
+            </td>
+          </tr>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -854,6 +946,8 @@ exports[`TableComponent supports a scoped slot inside the table column 1`] = `
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -902,6 +996,8 @@ exports[`TableComponent will use the property name as a column heading if label 
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->
@@ -949,6 +1045,8 @@ exports[`TableComponent won't use the property name as a column heading if label
             </td>
           </tr>
         </tbody>
+        <tfoot>
+        </tfoot>
       </table>
     </div>
     <!---->

--- a/__tests__/components/table-component/__snapshots__/filter.test.js.snap
+++ b/__tests__/components/table-component/__snapshots__/filter.test.js.snap
@@ -53,6 +53,8 @@ exports[`Filterable tableComponent can add a custom html class on the filter inp
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -116,6 +118,8 @@ exports[`Filterable tableComponent can filter data 1`] = `
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -170,6 +174,8 @@ exports[`Filterable tableComponent can filter on another property 1`] = `
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -230,6 +236,8 @@ exports[`Filterable tableComponent hides the filter when no columns are filterab
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -285,6 +293,8 @@ exports[`Filterable tableComponent will display a message if there are no matchi
           </thead>
           <tbody class="table-component__table__body">
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <div class="table-component__message">
@@ -351,6 +361,8 @@ exports[`Filterable tableComponent will filter data in a case-insensitive way 1`
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -407,6 +419,8 @@ exports[`Filterable tableComponent will not use columns that are not filterable 
           </thead>
           <tbody class="table-component__table__body">
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <div class="table-component__message">

--- a/__tests__/components/table-component/__snapshots__/sort.test.js.snap
+++ b/__tests__/components/table-component/__snapshots__/sort.test.js.snap
@@ -72,6 +72,8 @@ exports[`Sortable tableComponent can sort on another column 1`] = `
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -177,6 +179,8 @@ exports[`Sortable tableComponent can sort the data with by a specific column 1`]
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -283,6 +287,8 @@ exports[`Sortable tableComponent can sort the data with by a specific column in 
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -389,6 +395,8 @@ exports[`Sortable tableComponent can sort the data with by another specific colu
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -495,6 +503,8 @@ exports[`Sortable tableComponent it will change the sort order when clicking the
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -601,6 +611,8 @@ exports[`Sortable tableComponent will not sort data when clicking a non-sortable
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -707,6 +719,8 @@ exports[`Sortable tableComponent will not sort on a column that is not sortable 
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -813,6 +827,8 @@ exports[`Sortable tableComponent will sort the data ascendingly if the header of
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->
@@ -915,6 +931,8 @@ exports[`Sortable tableComponent wont break if a sortable column has no data 1`]
               </td>
             </tr>
           </tbody>
+          <tfoot>
+          </tfoot>
         </table>
       </div>
       <!---->

--- a/docs/build/app.js
+++ b/docs/build/app.js
@@ -63,7 +63,7 @@
 /******/ 	__webpack_require__.p = "/build/";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 198);
+/******/ 	return __webpack_require__(__webpack_require__.s = 197);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -1899,7 +1899,7 @@ function loadLocale(name) {
             module && module.exports) {
         try {
             oldLocale = globalLocale._abbr;
-            __webpack_require__(337)("./" + name);
+            __webpack_require__(336)("./" + name);
             // because defineLocale currently also sets the global locale, we
             // want to undo that for lazy loaded locales
             getSetGlobalLocale(oldLocale);
@@ -4540,8 +4540,8 @@ return hooks;
 /* 1 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var store      = __webpack_require__(58)('wks')
-  , uid        = __webpack_require__(61)
+var store      = __webpack_require__(56)('wks')
+  , uid        = __webpack_require__(60)
   , Symbol     = __webpack_require__(2).Symbol
   , USE_SYMBOL = typeof Symbol == 'function';
 
@@ -4563,6 +4563,13 @@ if(typeof __g == 'number')__g = global; // eslint-disable-line no-undef
 
 /***/ }),
 /* 3 */
+/***/ (function(module, exports) {
+
+var core = module.exports = {version: '2.4.0'};
+if(typeof __e == 'number')__e = core; // eslint-disable-line no-undef
+
+/***/ }),
+/* 4 */
 /***/ (function(module, exports) {
 
 /**
@@ -4594,7 +4601,7 @@ module.exports = isArray;
 
 
 /***/ }),
-/* 4 */
+/* 5 */
 /***/ (function(module, exports) {
 
 /**
@@ -4631,17 +4638,10 @@ module.exports = isObject;
 
 
 /***/ }),
-/* 5 */
-/***/ (function(module, exports) {
-
-var core = module.exports = {version: '2.4.0'};
-if(typeof __e == 'number')__e = core; // eslint-disable-line no-undef
-
-/***/ }),
 /* 6 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(18);
+var isObject = __webpack_require__(19);
 module.exports = function(it){
   if(!isObject(it))throw TypeError(it + ' is not an object!');
   return it;
@@ -4652,7 +4652,7 @@ module.exports = function(it){
 /***/ (function(module, exports, __webpack_require__) {
 
 // Thank's IE8 for his funny defineProperty
-module.exports = !__webpack_require__(53)(function(){
+module.exports = !__webpack_require__(37)(function(){
   return Object.defineProperty({}, 'a', {get: function(){ return 7; }}).a != 7;
 });
 
@@ -4661,7 +4661,7 @@ module.exports = !__webpack_require__(53)(function(){
 /***/ (function(module, exports, __webpack_require__) {
 
 var dP         = __webpack_require__(12)
-  , createDesc = __webpack_require__(57);
+  , createDesc = __webpack_require__(55);
 module.exports = __webpack_require__(7) ? function(object, key, value){
   return dP.f(object, key, createDesc(1, value));
 } : function(object, key, value){
@@ -4671,15 +4671,9 @@ module.exports = __webpack_require__(7) ? function(object, key, value){
 
 /***/ }),
 /* 9 */
-/***/ (function(module, exports) {
-
-module.exports = {};
-
-/***/ }),
-/* 10 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var freeGlobal = __webpack_require__(69);
+var freeGlobal = __webpack_require__(67);
 
 /** Detect free variable `self`. */
 var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
@@ -4691,7 +4685,7 @@ module.exports = root;
 
 
 /***/ }),
-/* 11 */
+/* 10 */
 /***/ (function(module, exports) {
 
 /**
@@ -4726,12 +4720,18 @@ module.exports = isObjectLike;
 
 
 /***/ }),
+/* 11 */
+/***/ (function(module, exports) {
+
+module.exports = {};
+
+/***/ }),
 /* 12 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var anObject       = __webpack_require__(6)
-  , IE8_DOM_DEFINE = __webpack_require__(223)
-  , toPrimitive    = __webpack_require__(244)
+  , IE8_DOM_DEFINE = __webpack_require__(221)
+  , toPrimitive    = __webpack_require__(241)
   , dP             = Object.defineProperty;
 
 exports.f = __webpack_require__(7) ? Object.defineProperty : function defineProperty(O, P, Attributes){
@@ -4750,9 +4750,9 @@ exports.f = __webpack_require__(7) ? Object.defineProperty : function defineProp
 /* 13 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Symbol = __webpack_require__(20),
-    getRawTag = __webpack_require__(287),
-    objectToString = __webpack_require__(313);
+var Symbol = __webpack_require__(21),
+    getRawTag = __webpack_require__(286),
+    objectToString = __webpack_require__(312);
 
 /** `Object#toString` result references. */
 var nullTag = '[object Null]',
@@ -4914,528 +4914,10 @@ module.exports = function(fn, that, length){
 
 /***/ }),
 /* 17 */
-/***/ (function(module, exports) {
-
-var hasOwnProperty = {}.hasOwnProperty;
-module.exports = function(it, key){
-  return hasOwnProperty.call(it, key);
-};
-
-/***/ }),
-/* 18 */
-/***/ (function(module, exports) {
-
-module.exports = function(it){
-  return typeof it === 'object' ? it !== null : typeof it === 'function';
-};
-
-/***/ }),
-/* 19 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var listCacheClear = __webpack_require__(300),
-    listCacheDelete = __webpack_require__(301),
-    listCacheGet = __webpack_require__(302),
-    listCacheHas = __webpack_require__(303),
-    listCacheSet = __webpack_require__(304);
-
-/**
- * Creates an list cache object.
- *
- * @private
- * @constructor
- * @param {Array} [entries] The key-value pairs to cache.
- */
-function ListCache(entries) {
-  var index = -1,
-      length = entries == null ? 0 : entries.length;
-
-  this.clear();
-  while (++index < length) {
-    var entry = entries[index];
-    this.set(entry[0], entry[1]);
-  }
-}
-
-// Add methods to `ListCache`.
-ListCache.prototype.clear = listCacheClear;
-ListCache.prototype['delete'] = listCacheDelete;
-ListCache.prototype.get = listCacheGet;
-ListCache.prototype.has = listCacheHas;
-ListCache.prototype.set = listCacheSet;
-
-module.exports = ListCache;
-
-
-/***/ }),
-/* 20 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var root = __webpack_require__(10);
-
-/** Built-in value references. */
-var Symbol = root.Symbol;
-
-module.exports = Symbol;
-
-
-/***/ }),
-/* 21 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var eq = __webpack_require__(26);
-
-/**
- * Gets the index at which the `key` is found in `array` of key-value pairs.
- *
- * @private
- * @param {Array} array The array to inspect.
- * @param {*} key The key to search for.
- * @returns {number} Returns the index of the matched value, else `-1`.
- */
-function assocIndexOf(array, key) {
-  var length = array.length;
-  while (length--) {
-    if (eq(array[length][0], key)) {
-      return length;
-    }
-  }
-  return -1;
-}
-
-module.exports = assocIndexOf;
-
-
-/***/ }),
-/* 22 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isArray = __webpack_require__(3),
-    isKey = __webpack_require__(297),
-    stringToPath = __webpack_require__(321),
-    toString = __webpack_require__(336);
-
-/**
- * Casts `value` to a path array if it's not one.
- *
- * @private
- * @param {*} value The value to inspect.
- * @param {Object} [object] The object to query keys on.
- * @returns {Array} Returns the cast property path array.
- */
-function castPath(value, object) {
-  if (isArray(value)) {
-    return value;
-  }
-  return isKey(value, object) ? [value] : stringToPath(toString(value));
-}
-
-module.exports = castPath;
-
-
-/***/ }),
-/* 23 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isKeyable = __webpack_require__(298);
-
-/**
- * Gets the data for `map`.
- *
- * @private
- * @param {Object} map The map to query.
- * @param {string} key The reference key.
- * @returns {*} Returns the map data.
- */
-function getMapData(map, key) {
-  var data = map.__data__;
-  return isKeyable(key)
-    ? data[typeof key == 'string' ? 'string' : 'hash']
-    : data.map;
-}
-
-module.exports = getMapData;
-
-
-/***/ }),
-/* 24 */
-/***/ (function(module, exports) {
-
-/** Used as references for various `Number` constants. */
-var MAX_SAFE_INTEGER = 9007199254740991;
-
-/** Used to detect unsigned integer values. */
-var reIsUint = /^(?:0|[1-9]\d*)$/;
-
-/**
- * Checks if `value` is a valid array-like index.
- *
- * @private
- * @param {*} value The value to check.
- * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
- * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
- */
-function isIndex(value, length) {
-  length = length == null ? MAX_SAFE_INTEGER : length;
-  return !!length &&
-    (typeof value == 'number' || reIsUint.test(value)) &&
-    (value > -1 && value % 1 == 0 && value < length);
-}
-
-module.exports = isIndex;
-
-
-/***/ }),
-/* 25 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var getNative = __webpack_require__(46);
-
-/* Built-in method references that are verified to be native. */
-var nativeCreate = getNative(Object, 'create');
-
-module.exports = nativeCreate;
-
-
-/***/ }),
-/* 26 */
-/***/ (function(module, exports) {
-
-/**
- * Performs a
- * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
- * comparison between two values to determine if they are equivalent.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to compare.
- * @param {*} other The other value to compare.
- * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
- * @example
- *
- * var object = { 'a': 1 };
- * var other = { 'a': 1 };
- *
- * _.eq(object, object);
- * // => true
- *
- * _.eq(object, other);
- * // => false
- *
- * _.eq('a', 'a');
- * // => true
- *
- * _.eq('a', Object('a'));
- * // => false
- *
- * _.eq(NaN, NaN);
- * // => true
- */
-function eq(value, other) {
-  return value === other || (value !== value && other !== other);
-}
-
-module.exports = eq;
-
-
-/***/ }),
-/* 27 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var baseIsArguments = __webpack_require__(262),
-    isObjectLike = __webpack_require__(11);
-
-/** Used for built-in method references. */
-var objectProto = Object.prototype;
-
-/** Used to check objects for own properties. */
-var hasOwnProperty = objectProto.hasOwnProperty;
-
-/** Built-in value references. */
-var propertyIsEnumerable = objectProto.propertyIsEnumerable;
-
-/**
- * Checks if `value` is likely an `arguments` object.
- *
- * @static
- * @memberOf _
- * @since 0.1.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is an `arguments` object,
- *  else `false`.
- * @example
- *
- * _.isArguments(function() { return arguments; }());
- * // => true
- *
- * _.isArguments([1, 2, 3]);
- * // => false
- */
-var isArguments = baseIsArguments(function() { return arguments; }()) ? baseIsArguments : function(value) {
-  return isObjectLike(value) && hasOwnProperty.call(value, 'callee') &&
-    !propertyIsEnumerable.call(value, 'callee');
-};
-
-module.exports = isArguments;
-
-
-/***/ }),
-/* 28 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var baseGetTag = __webpack_require__(13),
-    isObjectLike = __webpack_require__(11);
-
-/** `Object#toString` result references. */
-var symbolTag = '[object Symbol]';
-
-/**
- * Checks if `value` is classified as a `Symbol` primitive or object.
- *
- * @static
- * @memberOf _
- * @since 4.0.0
- * @category Lang
- * @param {*} value The value to check.
- * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
- * @example
- *
- * _.isSymbol(Symbol.iterator);
- * // => true
- *
- * _.isSymbol('abc');
- * // => false
- */
-function isSymbol(value) {
-  return typeof value == 'symbol' ||
-    (isObjectLike(value) && baseGetTag(value) == symbolTag);
-}
-
-module.exports = isSymbol;
-
-
-/***/ }),
-/* 29 */
-/***/ (function(module, exports) {
-
-var g;
-
-// This works in non-strict mode
-g = (function() {
-	return this;
-})();
-
-try {
-	// This works if eval is allowed (see CSP)
-	g = g || Function("return this")() || (1,eval)("this");
-} catch(e) {
-	// This works if the window reference is available
-	if(typeof window === "object")
-		g = window;
-}
-
-// g can still be undefined, but nothing to do about it...
-// We return undefined, instead of nothing here, so it's
-// easier to handle this case. if(!global) { ...}
-
-module.exports = g;
-
-
-/***/ }),
-/* 30 */
-/***/ (function(module, exports) {
-
-module.exports = function(module) {
-	if(!module.webpackPolyfill) {
-		module.deprecate = function() {};
-		module.paths = [];
-		// module.parent = undefined by default
-		if(!module.children) module.children = [];
-		Object.defineProperty(module, "loaded", {
-			enumerable: true,
-			get: function() {
-				return module.l;
-			}
-		});
-		Object.defineProperty(module, "id", {
-			enumerable: true,
-			get: function() {
-				return module.i;
-			}
-		});
-		module.webpackPolyfill = 1;
-	}
-	return module;
-};
-
-
-/***/ }),
-/* 31 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
-    if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(330)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
-				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
-				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-    } else if (typeof exports !== "undefined") {
-        factory(exports, require('lodash/merge'));
-    } else {
-        var mod = {
-            exports: {}
-        };
-        factory(mod.exports, global.merge);
-        global.settings = mod.exports;
-    }
-})(this, function (exports, _merge) {
-    'use strict';
-
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    exports.mergeSettings = mergeSettings;
-
-    var _merge2 = _interopRequireDefault(_merge);
-
-    function _interopRequireDefault(obj) {
-        return obj && obj.__esModule ? obj : {
-            default: obj
-        };
-    }
-
-    var settings = {
-        tableClass: '',
-        headerClass: '',
-        cellClass: '',
-        filterInputClass: '',
-        filterPlaceholder: 'Filter table…',
-        filterNoResults: 'There are no matching rows'
-    };
-
-    function mergeSettings(newSettings) {
-        (0, _merge2.default)(settings, newSettings);
-    }
-
-    exports.default = settings;
-});
-
-/***/ }),
-/* 32 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-exports.__esModule = true;
-
-exports.default = function (instance, Constructor) {
-  if (!(instance instanceof Constructor)) {
-    throw new TypeError("Cannot call a class as a function");
-  }
-};
-
-/***/ }),
-/* 33 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-exports.__esModule = true;
-
-var _defineProperty = __webpack_require__(210);
-
-var _defineProperty2 = _interopRequireDefault(_defineProperty);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-exports.default = function () {
-  function defineProperties(target, props) {
-    for (var i = 0; i < props.length; i++) {
-      var descriptor = props[i];
-      descriptor.enumerable = descriptor.enumerable || false;
-      descriptor.configurable = true;
-      if ("value" in descriptor) descriptor.writable = true;
-      (0, _defineProperty2.default)(target, descriptor.key, descriptor);
-    }
-  }
-
-  return function (Constructor, protoProps, staticProps) {
-    if (protoProps) defineProperties(Constructor.prototype, protoProps);
-    if (staticProps) defineProperties(Constructor, staticProps);
-    return Constructor;
-  };
-}();
-
-/***/ }),
-/* 34 */
-/***/ (function(module, exports) {
-
-module.exports = function(it){
-  if(typeof it != 'function')throw TypeError(it + ' is not a function!');
-  return it;
-};
-
-/***/ }),
-/* 35 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// getting tag from 19.1.3.6 Object.prototype.toString()
-var cof = __webpack_require__(15)
-  , TAG = __webpack_require__(1)('toStringTag')
-  // ES3 wrong here
-  , ARG = cof(function(){ return arguments; }()) == 'Arguments';
-
-// fallback for IE11 Script Access Denied error
-var tryGet = function(it, key){
-  try {
-    return it[key];
-  } catch(e){ /* empty */ }
-};
-
-module.exports = function(it){
-  var O, T, B;
-  return it === undefined ? 'Undefined' : it === null ? 'Null'
-    // @@toStringTag case
-    : typeof (T = tryGet(O = Object(it), TAG)) == 'string' ? T
-    // builtinTag case
-    : ARG ? cof(O)
-    // ES3 arguments fallback
-    : (B = cof(O)) == 'Object' && typeof O.callee == 'function' ? 'Arguments' : B;
-};
-
-/***/ }),
-/* 36 */
-/***/ (function(module, exports) {
-
-// 7.2.1 RequireObjectCoercible(argument)
-module.exports = function(it){
-  if(it == undefined)throw TypeError("Can't call method on  " + it);
-  return it;
-};
-
-/***/ }),
-/* 37 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var isObject = __webpack_require__(18)
-  , document = __webpack_require__(2).document
-  // in old IE typeof document.createElement is 'object'
-  , is = isObject(document) && isObject(document.createElement);
-module.exports = function(it){
-  return is ? document.createElement(it) : {};
-};
-
-/***/ }),
-/* 38 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global    = __webpack_require__(2)
-  , core      = __webpack_require__(5)
+  , core      = __webpack_require__(3)
   , ctx       = __webpack_require__(16)
   , hide      = __webpack_require__(8)
   , PROTOTYPE = 'prototype';
@@ -5497,11 +4979,488 @@ $export.R = 128; // real proto method for `library`
 module.exports = $export;
 
 /***/ }),
-/* 39 */
+/* 18 */
+/***/ (function(module, exports) {
+
+var hasOwnProperty = {}.hasOwnProperty;
+module.exports = function(it, key){
+  return hasOwnProperty.call(it, key);
+};
+
+/***/ }),
+/* 19 */
+/***/ (function(module, exports) {
+
+module.exports = function(it){
+  return typeof it === 'object' ? it !== null : typeof it === 'function';
+};
+
+/***/ }),
+/* 20 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var listCacheClear = __webpack_require__(299),
+    listCacheDelete = __webpack_require__(300),
+    listCacheGet = __webpack_require__(301),
+    listCacheHas = __webpack_require__(302),
+    listCacheSet = __webpack_require__(303);
+
+/**
+ * Creates an list cache object.
+ *
+ * @private
+ * @constructor
+ * @param {Array} [entries] The key-value pairs to cache.
+ */
+function ListCache(entries) {
+  var index = -1,
+      length = entries == null ? 0 : entries.length;
+
+  this.clear();
+  while (++index < length) {
+    var entry = entries[index];
+    this.set(entry[0], entry[1]);
+  }
+}
+
+// Add methods to `ListCache`.
+ListCache.prototype.clear = listCacheClear;
+ListCache.prototype['delete'] = listCacheDelete;
+ListCache.prototype.get = listCacheGet;
+ListCache.prototype.has = listCacheHas;
+ListCache.prototype.set = listCacheSet;
+
+module.exports = ListCache;
+
+
+/***/ }),
+/* 21 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var root = __webpack_require__(9);
+
+/** Built-in value references. */
+var Symbol = root.Symbol;
+
+module.exports = Symbol;
+
+
+/***/ }),
+/* 22 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var eq = __webpack_require__(27);
+
+/**
+ * Gets the index at which the `key` is found in `array` of key-value pairs.
+ *
+ * @private
+ * @param {Array} array The array to inspect.
+ * @param {*} key The key to search for.
+ * @returns {number} Returns the index of the matched value, else `-1`.
+ */
+function assocIndexOf(array, key) {
+  var length = array.length;
+  while (length--) {
+    if (eq(array[length][0], key)) {
+      return length;
+    }
+  }
+  return -1;
+}
+
+module.exports = assocIndexOf;
+
+
+/***/ }),
+/* 23 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isArray = __webpack_require__(4),
+    isKey = __webpack_require__(296),
+    stringToPath = __webpack_require__(320),
+    toString = __webpack_require__(335);
+
+/**
+ * Casts `value` to a path array if it's not one.
+ *
+ * @private
+ * @param {*} value The value to inspect.
+ * @param {Object} [object] The object to query keys on.
+ * @returns {Array} Returns the cast property path array.
+ */
+function castPath(value, object) {
+  if (isArray(value)) {
+    return value;
+  }
+  return isKey(value, object) ? [value] : stringToPath(toString(value));
+}
+
+module.exports = castPath;
+
+
+/***/ }),
+/* 24 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isKeyable = __webpack_require__(297);
+
+/**
+ * Gets the data for `map`.
+ *
+ * @private
+ * @param {Object} map The map to query.
+ * @param {string} key The reference key.
+ * @returns {*} Returns the map data.
+ */
+function getMapData(map, key) {
+  var data = map.__data__;
+  return isKeyable(key)
+    ? data[typeof key == 'string' ? 'string' : 'hash']
+    : data.map;
+}
+
+module.exports = getMapData;
+
+
+/***/ }),
+/* 25 */
+/***/ (function(module, exports) {
+
+/** Used as references for various `Number` constants. */
+var MAX_SAFE_INTEGER = 9007199254740991;
+
+/** Used to detect unsigned integer values. */
+var reIsUint = /^(?:0|[1-9]\d*)$/;
+
+/**
+ * Checks if `value` is a valid array-like index.
+ *
+ * @private
+ * @param {*} value The value to check.
+ * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
+ * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
+ */
+function isIndex(value, length) {
+  length = length == null ? MAX_SAFE_INTEGER : length;
+  return !!length &&
+    (typeof value == 'number' || reIsUint.test(value)) &&
+    (value > -1 && value % 1 == 0 && value < length);
+}
+
+module.exports = isIndex;
+
+
+/***/ }),
+/* 26 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var getNative = __webpack_require__(43);
+
+/* Built-in method references that are verified to be native. */
+var nativeCreate = getNative(Object, 'create');
+
+module.exports = nativeCreate;
+
+
+/***/ }),
+/* 27 */
+/***/ (function(module, exports) {
+
+/**
+ * Performs a
+ * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
+ * comparison between two values to determine if they are equivalent.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to compare.
+ * @param {*} other The other value to compare.
+ * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
+ * @example
+ *
+ * var object = { 'a': 1 };
+ * var other = { 'a': 1 };
+ *
+ * _.eq(object, object);
+ * // => true
+ *
+ * _.eq(object, other);
+ * // => false
+ *
+ * _.eq('a', 'a');
+ * // => true
+ *
+ * _.eq('a', Object('a'));
+ * // => false
+ *
+ * _.eq(NaN, NaN);
+ * // => true
+ */
+function eq(value, other) {
+  return value === other || (value !== value && other !== other);
+}
+
+module.exports = eq;
+
+
+/***/ }),
+/* 28 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var baseIsArguments = __webpack_require__(261),
+    isObjectLike = __webpack_require__(10);
+
+/** Used for built-in method references. */
+var objectProto = Object.prototype;
+
+/** Used to check objects for own properties. */
+var hasOwnProperty = objectProto.hasOwnProperty;
+
+/** Built-in value references. */
+var propertyIsEnumerable = objectProto.propertyIsEnumerable;
+
+/**
+ * Checks if `value` is likely an `arguments` object.
+ *
+ * @static
+ * @memberOf _
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is an `arguments` object,
+ *  else `false`.
+ * @example
+ *
+ * _.isArguments(function() { return arguments; }());
+ * // => true
+ *
+ * _.isArguments([1, 2, 3]);
+ * // => false
+ */
+var isArguments = baseIsArguments(function() { return arguments; }()) ? baseIsArguments : function(value) {
+  return isObjectLike(value) && hasOwnProperty.call(value, 'callee') &&
+    !propertyIsEnumerable.call(value, 'callee');
+};
+
+module.exports = isArguments;
+
+
+/***/ }),
+/* 29 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var baseGetTag = __webpack_require__(13),
+    isObjectLike = __webpack_require__(10);
+
+/** `Object#toString` result references. */
+var symbolTag = '[object Symbol]';
+
+/**
+ * Checks if `value` is classified as a `Symbol` primitive or object.
+ *
+ * @static
+ * @memberOf _
+ * @since 4.0.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
+ * @example
+ *
+ * _.isSymbol(Symbol.iterator);
+ * // => true
+ *
+ * _.isSymbol('abc');
+ * // => false
+ */
+function isSymbol(value) {
+  return typeof value == 'symbol' ||
+    (isObjectLike(value) && baseGetTag(value) == symbolTag);
+}
+
+module.exports = isSymbol;
+
+
+/***/ }),
+/* 30 */
+/***/ (function(module, exports) {
+
+module.exports = function(module) {
+	if(!module.webpackPolyfill) {
+		module.deprecate = function() {};
+		module.paths = [];
+		// module.parent = undefined by default
+		if(!module.children) module.children = [];
+		Object.defineProperty(module, "loaded", {
+			enumerable: true,
+			get: function() {
+				return module.l;
+			}
+		});
+		Object.defineProperty(module, "id", {
+			enumerable: true,
+			get: function() {
+				return module.i;
+			}
+		});
+		module.webpackPolyfill = 1;
+	}
+	return module;
+};
+
+
+/***/ }),
+/* 31 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
+    if (true) {
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(329)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
+				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+    } else if (typeof exports !== "undefined") {
+        factory(exports, require('lodash/merge'));
+    } else {
+        var mod = {
+            exports: {}
+        };
+        factory(mod.exports, global.merge);
+        global.settings = mod.exports;
+    }
+})(this, function (exports, _merge) {
+    'use strict';
+
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    exports.mergeSettings = mergeSettings;
+
+    var _merge2 = _interopRequireDefault(_merge);
+
+    function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : {
+            default: obj
+        };
+    }
+
+    var settings = {
+        tableClass: '',
+        theadClass: '',
+        tbodyClass: '',
+        headerClass: '',
+        cellClass: '',
+        filterInputClass: '',
+        filterPlaceholder: 'Filter table…',
+        filterNoResults: 'There are no matching rows'
+    };
+
+    function mergeSettings(newSettings) {
+        (0, _merge2.default)(settings, newSettings);
+    }
+
+    exports.default = settings;
+});
+
+/***/ }),
+/* 32 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+exports.__esModule = true;
+
+exports.default = function (instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+};
+
+/***/ }),
+/* 33 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+exports.__esModule = true;
+
+var _defineProperty = __webpack_require__(208);
+
+var _defineProperty2 = _interopRequireDefault(_defineProperty);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      (0, _defineProperty2.default)(target, descriptor.key, descriptor);
+    }
+  }
+
+  return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+}();
+
+/***/ }),
+/* 34 */
+/***/ (function(module, exports) {
+
+module.exports = function(it){
+  if(typeof it != 'function')throw TypeError(it + ' is not a function!');
+  return it;
+};
+
+/***/ }),
+/* 35 */
+/***/ (function(module, exports) {
+
+// 7.2.1 RequireObjectCoercible(argument)
+module.exports = function(it){
+  if(it == undefined)throw TypeError("Can't call method on  " + it);
+  return it;
+};
+
+/***/ }),
+/* 36 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var isObject = __webpack_require__(19)
+  , document = __webpack_require__(2).document
+  // in old IE typeof document.createElement is 'object'
+  , is = isObject(document) && isObject(document.createElement);
+module.exports = function(it){
+  return is ? document.createElement(it) : {};
+};
+
+/***/ }),
+/* 37 */
+/***/ (function(module, exports) {
+
+module.exports = function(exec){
+  try {
+    return !!exec();
+  } catch(e){
+    return true;
+  }
+};
+
+/***/ }),
+/* 38 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var def = __webpack_require__(12).f
-  , has = __webpack_require__(17)
+  , has = __webpack_require__(18)
   , TAG = __webpack_require__(1)('toStringTag');
 
 module.exports = function(it, tag, stat){
@@ -5509,17 +5468,17 @@ module.exports = function(it, tag, stat){
 };
 
 /***/ }),
-/* 40 */
+/* 39 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var shared = __webpack_require__(58)('keys')
-  , uid    = __webpack_require__(61);
+var shared = __webpack_require__(56)('keys')
+  , uid    = __webpack_require__(60);
 module.exports = function(key){
   return shared[key] || (shared[key] = uid(key));
 };
 
 /***/ }),
-/* 41 */
+/* 40 */
 /***/ (function(module, exports) {
 
 // 7.1.4 ToInteger
@@ -5530,62 +5489,21 @@ module.exports = function(it){
 };
 
 /***/ }),
-/* 42 */
+/* 41 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // to indexed object, toObject with fallback for non-array-like ES3 strings
-var IObject = __webpack_require__(225)
-  , defined = __webpack_require__(36);
+var IObject = __webpack_require__(223)
+  , defined = __webpack_require__(35);
 module.exports = function(it){
   return IObject(defined(it));
 };
 
 /***/ }),
-/* 43 */
+/* 42 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-
-var $at  = __webpack_require__(241)(true);
-
-// 21.1.3.27 String.prototype[@@iterator]()
-__webpack_require__(55)(String, 'String', function(iterated){
-  this._t = String(iterated); // target
-  this._i = 0;                // next index
-// 21.1.5.2.1 %StringIteratorPrototype%.next()
-}, function(){
-  var O     = this._t
-    , index = this._i
-    , point;
-  if(index >= O.length)return {value: undefined, done: true};
-  point = $at(O, index);
-  this._i += point.length;
-  return {value: point, done: false};
-});
-
-/***/ }),
-/* 44 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(247);
-var global        = __webpack_require__(2)
-  , hide          = __webpack_require__(8)
-  , Iterators     = __webpack_require__(9)
-  , TO_STRING_TAG = __webpack_require__(1)('toStringTag');
-
-for(var collections = ['NodeList', 'DOMTokenList', 'MediaList', 'StyleSheetList', 'CSSRuleList'], i = 0; i < 5; i++){
-  var NAME       = collections[i]
-    , Collection = global[NAME]
-    , proto      = Collection && Collection.prototype;
-  if(proto && !proto[TO_STRING_TAG])hide(proto, TO_STRING_TAG, NAME);
-  Iterators[NAME] = Iterators.Array;
-}
-
-/***/ }),
-/* 45 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var defineProperty = __webpack_require__(68);
+var defineProperty = __webpack_require__(66);
 
 /**
  * The base implementation of `assignValue` and `assignMergeValue` without
@@ -5613,11 +5531,11 @@ module.exports = baseAssignValue;
 
 
 /***/ }),
-/* 46 */
+/* 43 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseIsNative = __webpack_require__(263),
-    getValue = __webpack_require__(288);
+var baseIsNative = __webpack_require__(262),
+    getValue = __webpack_require__(287);
 
 /**
  * Gets the native function at `key` of `object`.
@@ -5636,10 +5554,10 @@ module.exports = getNative;
 
 
 /***/ }),
-/* 47 */
+/* 44 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isSymbol = __webpack_require__(28);
+var isSymbol = __webpack_require__(29);
 
 /** Used as references for various `Number` constants. */
 var INFINITY = 1 / 0;
@@ -5663,11 +5581,11 @@ module.exports = toKey;
 
 
 /***/ }),
-/* 48 */
+/* 45 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isFunction = __webpack_require__(49),
-    isLength = __webpack_require__(50);
+var isFunction = __webpack_require__(46),
+    isLength = __webpack_require__(47);
 
 /**
  * Checks if `value` is array-like. A value is considered array-like if it's
@@ -5702,11 +5620,11 @@ module.exports = isArrayLike;
 
 
 /***/ }),
-/* 49 */
+/* 46 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var baseGetTag = __webpack_require__(13),
-    isObject = __webpack_require__(4);
+    isObject = __webpack_require__(5);
 
 /** `Object#toString` result references. */
 var asyncTag = '[object AsyncFunction]',
@@ -5745,7 +5663,7 @@ module.exports = isFunction;
 
 
 /***/ }),
-/* 50 */
+/* 47 */
 /***/ (function(module, exports) {
 
 /** Used as references for various `Number` constants. */
@@ -5786,12 +5704,12 @@ module.exports = isLength;
 
 
 /***/ }),
-/* 51 */
+/* 48 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(3)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(4)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -5834,7 +5752,35 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 52 */
+/* 49 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// getting tag from 19.1.3.6 Object.prototype.toString()
+var cof = __webpack_require__(15)
+  , TAG = __webpack_require__(1)('toStringTag')
+  // ES3 wrong here
+  , ARG = cof(function(){ return arguments; }()) == 'Arguments';
+
+// fallback for IE11 Script Access Denied error
+var tryGet = function(it, key){
+  try {
+    return it[key];
+  } catch(e){ /* empty */ }
+};
+
+module.exports = function(it){
+  var O, T, B;
+  return it === undefined ? 'Undefined' : it === null ? 'Null'
+    // @@toStringTag case
+    : typeof (T = tryGet(O = Object(it), TAG)) == 'string' ? T
+    // builtinTag case
+    : ARG ? cof(O)
+    // ES3 arguments fallback
+    : (B = cof(O)) == 'Object' && typeof O.callee == 'function' ? 'Arguments' : B;
+};
+
+/***/ }),
+/* 50 */
 /***/ (function(module, exports) {
 
 // IE 8- don't enum bug keys
@@ -5843,38 +5789,26 @@ module.exports = (
 ).split(',');
 
 /***/ }),
-/* 53 */
-/***/ (function(module, exports) {
-
-module.exports = function(exec){
-  try {
-    return !!exec();
-  } catch(e){
-    return true;
-  }
-};
-
-/***/ }),
-/* 54 */
+/* 51 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(2).document && document.documentElement;
 
 /***/ }),
-/* 55 */
+/* 52 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var LIBRARY        = __webpack_require__(56)
-  , $export        = __webpack_require__(38)
-  , redefine       = __webpack_require__(238)
+var LIBRARY        = __webpack_require__(53)
+  , $export        = __webpack_require__(17)
+  , redefine       = __webpack_require__(236)
   , hide           = __webpack_require__(8)
-  , has            = __webpack_require__(17)
-  , Iterators      = __webpack_require__(9)
-  , $iterCreate    = __webpack_require__(228)
-  , setToStringTag = __webpack_require__(39)
-  , getPrototypeOf = __webpack_require__(234)
+  , has            = __webpack_require__(18)
+  , Iterators      = __webpack_require__(11)
+  , $iterCreate    = __webpack_require__(226)
+  , setToStringTag = __webpack_require__(38)
+  , getPrototypeOf = __webpack_require__(232)
   , ITERATOR       = __webpack_require__(1)('iterator')
   , BUGGY          = !([].keys && 'next' in [].keys()) // Safari has buggy iterators w/o `next`
   , FF_ITERATOR    = '@@iterator'
@@ -5937,13 +5871,25 @@ module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED
 };
 
 /***/ }),
-/* 56 */
+/* 53 */
 /***/ (function(module, exports) {
 
 module.exports = true;
 
 /***/ }),
-/* 57 */
+/* 54 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// 19.1.2.14 / 15.2.3.14 Object.keys(O)
+var $keys       = __webpack_require__(233)
+  , enumBugKeys = __webpack_require__(50);
+
+module.exports = Object.keys || function keys(O){
+  return $keys(O, enumBugKeys);
+};
+
+/***/ }),
+/* 55 */
 /***/ (function(module, exports) {
 
 module.exports = function(bitmap, value){
@@ -5956,7 +5902,7 @@ module.exports = function(bitmap, value){
 };
 
 /***/ }),
-/* 58 */
+/* 56 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global = __webpack_require__(2)
@@ -5967,13 +5913,13 @@ module.exports = function(key){
 };
 
 /***/ }),
-/* 59 */
+/* 57 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ctx                = __webpack_require__(16)
-  , invoke             = __webpack_require__(224)
-  , html               = __webpack_require__(54)
-  , cel                = __webpack_require__(37)
+  , invoke             = __webpack_require__(222)
+  , html               = __webpack_require__(51)
+  , cel                = __webpack_require__(36)
   , global             = __webpack_require__(2)
   , process            = global.process
   , setTask            = global.setImmediate
@@ -6047,18 +5993,28 @@ module.exports = {
 };
 
 /***/ }),
-/* 60 */
+/* 58 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.1.15 ToLength
-var toInteger = __webpack_require__(41)
+var toInteger = __webpack_require__(40)
   , min       = Math.min;
 module.exports = function(it){
   return it > 0 ? min(toInteger(it), 0x1fffffffffffff) : 0; // pow(2, 53) - 1 == 9007199254740991
 };
 
 /***/ }),
-/* 61 */
+/* 59 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// 7.1.13 ToObject(argument)
+var defined = __webpack_require__(35);
+module.exports = function(it){
+  return Object(defined(it));
+};
+
+/***/ }),
+/* 60 */
 /***/ (function(module, exports) {
 
 var id = 0
@@ -6068,24 +6024,11 @@ module.exports = function(key){
 };
 
 /***/ }),
-/* 62 */
+/* 61 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var classof   = __webpack_require__(35)
-  , ITERATOR  = __webpack_require__(1)('iterator')
-  , Iterators = __webpack_require__(9);
-module.exports = __webpack_require__(5).getIteratorMethod = function(it){
-  if(it != undefined)return it[ITERATOR]
-    || it['@@iterator']
-    || Iterators[classof(it)];
-};
-
-/***/ }),
-/* 63 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var getNative = __webpack_require__(46),
-    root = __webpack_require__(10);
+var getNative = __webpack_require__(43),
+    root = __webpack_require__(9);
 
 /* Built-in method references that are verified to be native. */
 var Map = getNative(root, 'Map');
@@ -6094,14 +6037,14 @@ module.exports = Map;
 
 
 /***/ }),
-/* 64 */
+/* 62 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var mapCacheClear = __webpack_require__(305),
-    mapCacheDelete = __webpack_require__(306),
-    mapCacheGet = __webpack_require__(307),
-    mapCacheHas = __webpack_require__(308),
-    mapCacheSet = __webpack_require__(309);
+var mapCacheClear = __webpack_require__(304),
+    mapCacheDelete = __webpack_require__(305),
+    mapCacheGet = __webpack_require__(306),
+    mapCacheHas = __webpack_require__(307),
+    mapCacheSet = __webpack_require__(308);
 
 /**
  * Creates a map cache object to store key-value pairs.
@@ -6132,11 +6075,11 @@ module.exports = MapCache;
 
 
 /***/ }),
-/* 65 */
+/* 63 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseAssignValue = __webpack_require__(45),
-    eq = __webpack_require__(26);
+var baseAssignValue = __webpack_require__(42),
+    eq = __webpack_require__(27);
 
 /**
  * This function is like `assignValue` except that it doesn't assign
@@ -6158,11 +6101,11 @@ module.exports = assignMergeValue;
 
 
 /***/ }),
-/* 66 */
+/* 64 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseAssignValue = __webpack_require__(45),
-    eq = __webpack_require__(26);
+var baseAssignValue = __webpack_require__(42),
+    eq = __webpack_require__(27);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -6192,11 +6135,11 @@ module.exports = assignValue;
 
 
 /***/ }),
-/* 67 */
+/* 65 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var castPath = __webpack_require__(22),
-    toKey = __webpack_require__(47);
+var castPath = __webpack_require__(23),
+    toKey = __webpack_require__(44);
 
 /**
  * The base implementation of `_.get` without support for default values.
@@ -6222,10 +6165,10 @@ module.exports = baseGet;
 
 
 /***/ }),
-/* 68 */
+/* 66 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getNative = __webpack_require__(46);
+var getNative = __webpack_require__(43);
 
 var defineProperty = (function() {
   try {
@@ -6239,7 +6182,7 @@ module.exports = defineProperty;
 
 
 /***/ }),
-/* 69 */
+/* 67 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global) {/** Detect free variable `global` from Node.js. */
@@ -6247,13 +6190,13 @@ var freeGlobal = typeof global == 'object' && global && global.Object === Object
 
 module.exports = freeGlobal;
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(29)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(194)))
 
 /***/ }),
-/* 70 */
+/* 68 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var overArg = __webpack_require__(314);
+var overArg = __webpack_require__(313);
 
 /** Built-in value references. */
 var getPrototype = overArg(Object.getPrototypeOf, Object);
@@ -6262,13 +6205,13 @@ module.exports = getPrototype;
 
 
 /***/ }),
-/* 71 */
+/* 69 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var eq = __webpack_require__(26),
-    isArrayLike = __webpack_require__(48),
-    isIndex = __webpack_require__(24),
-    isObject = __webpack_require__(4);
+var eq = __webpack_require__(27),
+    isArrayLike = __webpack_require__(45),
+    isIndex = __webpack_require__(25),
+    isObject = __webpack_require__(5);
 
 /**
  * Checks if the given arguments are from an iteratee call.
@@ -6298,7 +6241,7 @@ module.exports = isIterateeCall;
 
 
 /***/ }),
-/* 72 */
+/* 70 */
 /***/ (function(module, exports) {
 
 /** Used for built-in method references. */
@@ -6322,10 +6265,10 @@ module.exports = isPrototype;
 
 
 /***/ }),
-/* 73 */
+/* 71 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var apply = __webpack_require__(254);
+var apply = __webpack_require__(253);
 
 /* Built-in method references for those with the same name as other `lodash` methods. */
 var nativeMax = Math.max;
@@ -6364,11 +6307,11 @@ module.exports = overRest;
 
 
 /***/ }),
-/* 74 */
+/* 72 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseSetToString = __webpack_require__(273),
-    shortOut = __webpack_require__(315);
+var baseSetToString = __webpack_require__(272),
+    shortOut = __webpack_require__(314);
 
 /**
  * Sets the `toString` method of `func` to return `string`.
@@ -6384,7 +6327,7 @@ module.exports = setToString;
 
 
 /***/ }),
-/* 75 */
+/* 73 */
 /***/ (function(module, exports) {
 
 /**
@@ -6411,11 +6354,11 @@ module.exports = identity;
 
 
 /***/ }),
-/* 76 */
+/* 74 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(10),
-    stubFalse = __webpack_require__(332);
+/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(9),
+    stubFalse = __webpack_require__(331);
 
 /** Detect free variable `exports`. */
 var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -6456,12 +6399,12 @@ module.exports = isBuffer;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(30)(module)))
 
 /***/ }),
-/* 77 */
+/* 75 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseIsTypedArray = __webpack_require__(264),
-    baseUnary = __webpack_require__(276),
-    nodeUtil = __webpack_require__(312);
+var baseIsTypedArray = __webpack_require__(263),
+    baseUnary = __webpack_require__(275),
+    nodeUtil = __webpack_require__(311);
 
 /* Node.js helper references. */
 var nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
@@ -6489,12 +6432,12 @@ module.exports = isTypedArray;
 
 
 /***/ }),
-/* 78 */
+/* 76 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var arrayLikeKeys = __webpack_require__(255),
-    baseKeysIn = __webpack_require__(265),
-    isArrayLike = __webpack_require__(48);
+var arrayLikeKeys = __webpack_require__(254),
+    baseKeysIn = __webpack_require__(264),
+    isArrayLike = __webpack_require__(45);
 
 /**
  * Creates an array of the own and inherited enumerable property names of `object`.
@@ -6527,11 +6470,11 @@ module.exports = keysIn;
 
 
 /***/ }),
-/* 79 */
+/* 77 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var basePick = __webpack_require__(268),
-    flatRest = __webpack_require__(286);
+var basePick = __webpack_require__(267),
+    flatRest = __webpack_require__(285);
 
 /**
  * Creates an object composed of the picked `object` properties.
@@ -6558,7 +6501,7 @@ module.exports = pick;
 
 
 /***/ }),
-/* 80 */
+/* 78 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -6636,7 +6579,7 @@ return af;
 
 
 /***/ }),
-/* 81 */
+/* 79 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -6700,7 +6643,7 @@ return arDz;
 
 
 /***/ }),
-/* 82 */
+/* 80 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -6764,7 +6707,7 @@ return arKw;
 
 
 /***/ }),
-/* 83 */
+/* 81 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -6895,7 +6838,7 @@ return arLy;
 
 
 /***/ }),
-/* 84 */
+/* 82 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -6960,7 +6903,7 @@ return arMa;
 
 
 /***/ }),
-/* 85 */
+/* 83 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7070,7 +7013,7 @@ return arSa;
 
 
 /***/ }),
-/* 86 */
+/* 84 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7134,7 +7077,7 @@ return arTn;
 
 
 /***/ }),
-/* 87 */
+/* 85 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7281,7 +7224,7 @@ return ar;
 
 
 /***/ }),
-/* 88 */
+/* 86 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7391,7 +7334,7 @@ return az;
 
 
 /***/ }),
-/* 89 */
+/* 87 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7530,7 +7473,7 @@ return be;
 
 
 /***/ }),
-/* 90 */
+/* 88 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7625,7 +7568,7 @@ return bg;
 
 
 /***/ }),
-/* 91 */
+/* 89 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7749,7 +7692,7 @@ return bn;
 
 
 /***/ }),
-/* 92 */
+/* 90 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7873,7 +7816,7 @@ return bo;
 
 
 /***/ }),
-/* 93 */
+/* 91 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -7986,7 +7929,7 @@ return br;
 
 
 /***/ }),
-/* 94 */
+/* 92 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8134,7 +8077,7 @@ return bs;
 
 
 /***/ }),
-/* 95 */
+/* 93 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8227,7 +8170,7 @@ return ca;
 
 
 /***/ }),
-/* 96 */
+/* 94 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8404,7 +8347,7 @@ return cs;
 
 
 /***/ }),
-/* 97 */
+/* 95 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8472,7 +8415,7 @@ return cv;
 
 
 /***/ }),
-/* 98 */
+/* 96 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8558,7 +8501,7 @@ return cy;
 
 
 /***/ }),
-/* 99 */
+/* 97 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8623,7 +8566,7 @@ return da;
 
 
 /***/ }),
-/* 100 */
+/* 98 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8707,7 +8650,7 @@ return deAt;
 
 
 /***/ }),
-/* 101 */
+/* 99 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8790,7 +8733,7 @@ return deCh;
 
 
 /***/ }),
-/* 102 */
+/* 100 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8873,7 +8816,7 @@ return de;
 
 
 /***/ }),
-/* 103 */
+/* 101 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -8978,7 +8921,7 @@ return dv;
 
 
 /***/ }),
-/* 104 */
+/* 102 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9083,7 +9026,7 @@ return el;
 
 
 /***/ }),
-/* 105 */
+/* 103 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9155,7 +9098,7 @@ return enAu;
 
 
 /***/ }),
-/* 106 */
+/* 104 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9223,7 +9166,7 @@ return enCa;
 
 
 /***/ }),
-/* 107 */
+/* 105 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9295,7 +9238,7 @@ return enGb;
 
 
 /***/ }),
-/* 108 */
+/* 106 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9367,7 +9310,7 @@ return enIe;
 
 
 /***/ }),
-/* 109 */
+/* 107 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9439,7 +9382,7 @@ return enNz;
 
 
 /***/ }),
-/* 110 */
+/* 108 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9517,7 +9460,7 @@ return eo;
 
 
 /***/ }),
-/* 111 */
+/* 109 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9604,7 +9547,7 @@ return esDo;
 
 
 /***/ }),
-/* 112 */
+/* 110 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9692,7 +9635,7 @@ return es;
 
 
 /***/ }),
-/* 113 */
+/* 111 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9777,7 +9720,7 @@ return et;
 
 
 /***/ }),
-/* 114 */
+/* 112 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9848,7 +9791,7 @@ return eu;
 
 
 /***/ }),
-/* 115 */
+/* 113 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -9960,7 +9903,7 @@ return fa;
 
 
 /***/ }),
-/* 116 */
+/* 114 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10072,7 +10015,7 @@ return fi;
 
 
 /***/ }),
-/* 117 */
+/* 115 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10137,7 +10080,7 @@ return fo;
 
 
 /***/ }),
-/* 118 */
+/* 116 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10216,7 +10159,7 @@ return frCa;
 
 
 /***/ }),
-/* 119 */
+/* 117 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10299,7 +10242,7 @@ return frCh;
 
 
 /***/ }),
-/* 120 */
+/* 118 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10387,7 +10330,7 @@ return fr;
 
 
 /***/ }),
-/* 121 */
+/* 119 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10467,7 +10410,7 @@ return fy;
 
 
 /***/ }),
-/* 122 */
+/* 120 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10548,7 +10491,7 @@ return gd;
 
 
 /***/ }),
-/* 123 */
+/* 121 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10630,7 +10573,7 @@ return gl;
 
 
 /***/ }),
-/* 124 */
+/* 122 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10757,7 +10700,7 @@ return gomLatn;
 
 
 /***/ }),
-/* 125 */
+/* 123 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10861,7 +10804,7 @@ return he;
 
 
 /***/ }),
-/* 126 */
+/* 124 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -10990,7 +10933,7 @@ return hi;
 
 
 /***/ }),
-/* 127 */
+/* 125 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11140,7 +11083,7 @@ return hr;
 
 
 /***/ }),
-/* 128 */
+/* 126 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11254,7 +11197,7 @@ return hu;
 
 
 /***/ }),
-/* 129 */
+/* 127 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11354,7 +11297,7 @@ return hyAm;
 
 
 /***/ }),
-/* 130 */
+/* 128 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11442,7 +11385,7 @@ return id;
 
 
 /***/ }),
-/* 131 */
+/* 129 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11574,7 +11517,7 @@ return is;
 
 
 /***/ }),
-/* 132 */
+/* 130 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11649,7 +11592,7 @@ return it;
 
 
 /***/ }),
-/* 133 */
+/* 131 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11734,7 +11677,7 @@ return ja;
 
 
 /***/ }),
-/* 134 */
+/* 132 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11822,7 +11765,7 @@ return jv;
 
 
 /***/ }),
-/* 135 */
+/* 133 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -11916,7 +11859,7 @@ return ka;
 
 
 /***/ }),
-/* 136 */
+/* 134 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12008,7 +11951,7 @@ return kk;
 
 
 /***/ }),
-/* 137 */
+/* 135 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12071,7 +12014,7 @@ return km;
 
 
 /***/ }),
-/* 138 */
+/* 136 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12202,7 +12145,7 @@ return kn;
 
 
 /***/ }),
-/* 139 */
+/* 137 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12276,7 +12219,7 @@ return ko;
 
 
 /***/ }),
-/* 140 */
+/* 138 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12369,7 +12312,7 @@ return ky;
 
 
 /***/ }),
-/* 141 */
+/* 139 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12511,7 +12454,7 @@ return lb;
 
 
 /***/ }),
-/* 142 */
+/* 140 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12586,7 +12529,7 @@ return lo;
 
 
 /***/ }),
-/* 143 */
+/* 141 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12708,7 +12651,7 @@ return lt;
 
 
 /***/ }),
-/* 144 */
+/* 142 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12810,7 +12753,7 @@ return lv;
 
 
 /***/ }),
-/* 145 */
+/* 143 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12926,7 +12869,7 @@ return me;
 
 
 /***/ }),
-/* 146 */
+/* 144 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -12995,7 +12938,7 @@ return mi;
 
 
 /***/ }),
-/* 147 */
+/* 145 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13090,7 +13033,7 @@ return mk;
 
 
 /***/ }),
-/* 148 */
+/* 146 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13176,7 +13119,7 @@ return ml;
 
 
 /***/ }),
-/* 149 */
+/* 147 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13340,7 +13283,7 @@ return mr;
 
 
 /***/ }),
-/* 150 */
+/* 148 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13428,7 +13371,7 @@ return msMy;
 
 
 /***/ }),
-/* 151 */
+/* 149 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13515,7 +13458,7 @@ return ms;
 
 
 /***/ }),
-/* 152 */
+/* 150 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13616,7 +13559,7 @@ return my;
 
 
 /***/ }),
-/* 153 */
+/* 151 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13684,7 +13627,7 @@ return nb;
 
 
 /***/ }),
-/* 154 */
+/* 152 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13812,7 +13755,7 @@ return ne;
 
 
 /***/ }),
-/* 155 */
+/* 153 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13905,7 +13848,7 @@ return nlBe;
 
 
 /***/ }),
-/* 156 */
+/* 154 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -13998,7 +13941,7 @@ return nl;
 
 
 /***/ }),
-/* 157 */
+/* 155 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14063,7 +14006,7 @@ return nn;
 
 
 /***/ }),
-/* 158 */
+/* 156 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14192,7 +14135,7 @@ return paIn;
 
 
 /***/ }),
-/* 159 */
+/* 157 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14304,7 +14247,7 @@ return pl;
 
 
 /***/ }),
-/* 160 */
+/* 158 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14370,7 +14313,7 @@ return ptBr;
 
 
 /***/ }),
-/* 161 */
+/* 159 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14440,7 +14383,7 @@ return pt;
 
 
 /***/ }),
-/* 162 */
+/* 160 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14520,7 +14463,7 @@ return ro;
 
 
 /***/ }),
-/* 163 */
+/* 161 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14708,7 +14651,7 @@ return ru;
 
 
 /***/ }),
-/* 164 */
+/* 162 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14811,7 +14754,7 @@ return sd;
 
 
 /***/ }),
-/* 165 */
+/* 163 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14877,7 +14820,7 @@ return se;
 
 
 /***/ }),
-/* 166 */
+/* 164 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -14953,7 +14896,7 @@ return si;
 
 
 /***/ }),
-/* 167 */
+/* 165 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15108,7 +15051,7 @@ return sk;
 
 
 /***/ }),
-/* 168 */
+/* 166 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15275,7 +15218,7 @@ return sl;
 
 
 /***/ }),
-/* 169 */
+/* 167 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15350,7 +15293,7 @@ return sq;
 
 
 /***/ }),
-/* 170 */
+/* 168 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15465,7 +15408,7 @@ return srCyrl;
 
 
 /***/ }),
-/* 171 */
+/* 169 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15580,7 +15523,7 @@ return sr;
 
 
 /***/ }),
-/* 172 */
+/* 170 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15674,7 +15617,7 @@ return ss;
 
 
 /***/ }),
-/* 173 */
+/* 171 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15748,7 +15691,7 @@ return sv;
 
 
 /***/ }),
-/* 174 */
+/* 172 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15812,7 +15755,7 @@ return sw;
 
 
 /***/ }),
-/* 175 */
+/* 173 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -15947,7 +15890,7 @@ return ta;
 
 
 /***/ }),
-/* 176 */
+/* 174 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16041,7 +15984,7 @@ return te;
 
 
 /***/ }),
-/* 177 */
+/* 175 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16114,7 +16057,7 @@ return tet;
 
 
 /***/ }),
-/* 178 */
+/* 176 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16186,7 +16129,7 @@ return th;
 
 
 /***/ }),
-/* 179 */
+/* 177 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16253,7 +16196,7 @@ return tlPh;
 
 
 /***/ }),
-/* 180 */
+/* 178 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16378,7 +16321,7 @@ return tlh;
 
 
 /***/ }),
-/* 181 */
+/* 179 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16473,7 +16416,7 @@ return tr;
 
 
 /***/ }),
-/* 182 */
+/* 180 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16569,7 +16512,7 @@ return tzl;
 
 
 /***/ }),
-/* 183 */
+/* 181 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16632,7 +16575,7 @@ return tzmLatn;
 
 
 /***/ }),
-/* 184 */
+/* 182 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16695,7 +16638,7 @@ return tzm;
 
 
 /***/ }),
-/* 185 */
+/* 183 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16851,7 +16794,7 @@ return uk;
 
 
 /***/ }),
-/* 186 */
+/* 184 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -16955,7 +16898,7 @@ return ur;
 
 
 /***/ }),
-/* 187 */
+/* 185 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17018,7 +16961,7 @@ return uzLatn;
 
 
 /***/ }),
-/* 188 */
+/* 186 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17081,7 +17024,7 @@ return uz;
 
 
 /***/ }),
-/* 189 */
+/* 187 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17165,7 +17108,7 @@ return vi;
 
 
 /***/ }),
-/* 190 */
+/* 188 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17238,7 +17181,7 @@ return xPseudo;
 
 
 /***/ }),
-/* 191 */
+/* 189 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17303,7 +17246,7 @@ return yo;
 
 
 /***/ }),
-/* 192 */
+/* 190 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17419,7 +17362,7 @@ return zhCn;
 
 
 /***/ }),
-/* 193 */
+/* 191 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17529,7 +17472,7 @@ return zhHk;
 
 
 /***/ }),
-/* 194 */
+/* 192 */
 /***/ (function(module, exports, __webpack_require__) {
 
 //! moment.js locale configuration
@@ -17638,14 +17581,14 @@ return zhTw;
 
 
 /***/ }),
-/* 195 */
+/* 193 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var Component = __webpack_require__(14)(
   /* script */
-  __webpack_require__(199),
+  __webpack_require__(198),
   /* template */
-  __webpack_require__(347),
+  __webpack_require__(345),
   /* styles */
   null,
   /* scopeId */
@@ -17658,12 +17601,39 @@ module.exports = Component.exports
 
 
 /***/ }),
-/* 196 */
+/* 194 */
+/***/ (function(module, exports) {
+
+var g;
+
+// This works in non-strict mode
+g = (function() {
+	return this;
+})();
+
+try {
+	// This works if eval is allowed (see CSP)
+	g = g || Function("return this")() || (1,eval)("this");
+} catch(e) {
+	// This works if the window reference is available
+	if(typeof window === "object")
+		g = window;
+}
+
+// g can still be undefined, but nothing to do about it...
+// We return undefined, instead of nothing here, so it's
+// easier to handle this case. if(!global) { ...}
+
+module.exports = g;
+
+
+/***/ }),
+/* 195 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(343), __webpack_require__(341), __webpack_require__(195), __webpack_require__(31)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(341), __webpack_require__(339), __webpack_require__(193), __webpack_require__(31)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -17711,7 +17681,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 197 */
+/* 196 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(global) {/*!
@@ -27793,15 +27763,15 @@ return Vue$3;
 
 })));
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(29)))
+/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(194)))
 
 /***/ }),
-/* 198 */
+/* 197 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(197), __webpack_require__(196)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [__webpack_require__(196), __webpack_require__(195)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -27836,12 +27806,12 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 199 */
+/* 198 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(331)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(330)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -27914,7 +27884,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 200 */
+/* 199 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
@@ -27972,12 +27942,12 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 201 */
+/* 200 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(51)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(48)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -28052,25 +28022,25 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 202 */
+/* 201 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(214), __webpack_require__(212), __webpack_require__(204), __webpack_require__(207), __webpack_require__(205), __webpack_require__(342), __webpack_require__(344), __webpack_require__(31), __webpack_require__(3), __webpack_require__(79), __webpack_require__(195), __webpack_require__(51)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(212), __webpack_require__(209), __webpack_require__(211), __webpack_require__(203), __webpack_require__(206), __webpack_require__(204), __webpack_require__(340), __webpack_require__(342), __webpack_require__(31), __webpack_require__(4), __webpack_require__(77), __webpack_require__(193), __webpack_require__(48)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
     } else if (typeof exports !== "undefined") {
-        factory(exports, require('babel-runtime/regenerator'), require('babel-runtime/helpers/asyncToGenerator'), require('../classes/Column'), require('../expiring-storage'), require('../classes/Row'), require('./TableColumnHeader'), require('./TableRow'), require('../settings'), require('lodash/isArray'), require('lodash/pick'), require('./Pagination'), require('../helpers'));
+        factory(exports, require('babel-runtime/regenerator'), require('babel-runtime/core-js/object/keys'), require('babel-runtime/helpers/asyncToGenerator'), require('../classes/Column'), require('../expiring-storage'), require('../classes/Row'), require('./TableColumnHeader'), require('./TableRow'), require('../settings'), require('lodash/isArray'), require('lodash/pick'), require('./Pagination'), require('../helpers'));
     } else {
         var mod = {
             exports: {}
         };
-        factory(mod.exports, global.regenerator, global.asyncToGenerator, global.Column, global.expiringStorage, global.Row, global.TableColumnHeader, global.TableRow, global.settings, global.isArray, global.pick, global.Pagination, global.helpers);
+        factory(mod.exports, global.regenerator, global.keys, global.asyncToGenerator, global.Column, global.expiringStorage, global.Row, global.TableColumnHeader, global.TableRow, global.settings, global.isArray, global.pick, global.Pagination, global.helpers);
         global.TableComponent = mod.exports;
     }
-})(this, function (exports, _regenerator, _asyncToGenerator2, _Column, _expiringStorage, _Row, _TableColumnHeader, _TableRow, _settings, _isArray, _pick, _Pagination, _helpers) {
+})(this, function (exports, _regenerator, _keys, _asyncToGenerator2, _Column, _expiringStorage, _Row, _TableColumnHeader, _TableRow, _settings, _isArray, _pick, _Pagination, _helpers) {
     'use strict';
 
     Object.defineProperty(exports, "__esModule", {
@@ -28078,6 +28048,8 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
     });
 
     var _regenerator2 = _interopRequireDefault(_regenerator);
+
+    var _keys2 = _interopRequireDefault(_keys);
 
     var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
 
@@ -28123,10 +28095,12 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
             sortBy: { default: '', type: String },
             sortOrder: { default: '', type: String },
 
-            cacheId: { default: '' },
+            cacheKey: { default: null },
             cacheLifetime: { default: 5 },
 
             tableClass: { default: _settings2.default.tableClass },
+            theadClass: { default: _settings2.default.theadClass },
+            tbodyClass: { default: _settings2.default.tbodyClass },
             filterInputClass: { default: _settings2.default.filterInputClass },
             filterPlaceholder: { default: _settings2.default.filterPlaceholder },
             filterNoResults: { default: _settings2.default.filterNoResults }
@@ -28155,20 +28129,38 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
         },
         mounted: function () {
             var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee() {
+                var _this = this;
+
+                var columnComponents;
                 return _regenerator2.default.wrap(function _callee$(_context) {
                     while (1) {
                         switch (_context.prev = _context.next) {
                             case 0:
-                                this.columns = this.$slots.default.filter(function (column) {
+                                columnComponents = this.$slots.default.filter(function (column) {
                                     return column.componentInstance;
                                 }).map(function (column) {
-                                    return new _Column2.default(column.componentInstance);
+                                    return column.componentInstance;
                                 });
 
-                                _context.next = 3;
+
+                                this.columns = columnComponents.map(function (column) {
+                                    return new _Column2.default(column);
+                                });
+
+                                columnComponents.forEach(function (columnCom) {
+                                    (0, _keys2.default)(columnCom.$options.props).forEach(function (prop) {
+                                        return columnCom.$watch(prop, function () {
+                                            _this.columns = columnComponents.map(function (column) {
+                                                return new _Column2.default(column);
+                                            });
+                                        });
+                                    });
+                                });
+
+                                _context.next = 5;
                                 return this.mapDataToRows();
 
-                            case 3:
+                            case 5:
                             case 'end':
                                 return _context.stop();
                         }
@@ -28203,6 +28195,12 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
             fullTableClass: function fullTableClass() {
                 return (0, _helpers.classList)('table-component__table', this.tableClass);
             },
+            fullTableHeadClass: function fullTableHeadClass() {
+                return (0, _helpers.classList)('table-component__table__head', this.theadClass);
+            },
+            fullTableBodyClass: function fullTableBodyClass() {
+                return (0, _helpers.classList)('table-component__table__body', this.tbodyClass);
+            },
             fullFilterInputClass: function fullFilterInputClass() {
                 return (0, _helpers.classList)('table-component__filter__field', this.filterInputClass);
             },
@@ -28217,14 +28215,24 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
                 return (0, _isArray2.default)(this.data);
             },
             displayedRows: function displayedRows() {
-                var _this = this;
+                var _this2 = this;
 
                 if (!this.usesLocalData) {
                     return this.sortedRows;
                 }
 
+                if (!this.showFilter) {
+                    return this.sortedRows;
+                }
+
+                if (!this.columns.filter(function (column) {
+                    return column.isFilterable();
+                }).length) {
+                    return this.sortedRows;
+                }
+
                 return this.sortedRows.filter(function (row) {
-                    return row.passesFilter(_this.filter);
+                    return row.passesFilter(_this2.filter);
                 });
             },
             sortedRows: function sortedRows() {
@@ -28248,8 +28256,13 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 
                 return this.rows.sort(sortColumn.getSortPredicate(this.sort.order, this.columns));
             },
+            filterableColumnExists: function filterableColumnExists() {
+                return this.columns.filter(function (c) {
+                    return c.isFilterable();
+                }).length > 0;
+            },
             storageKey: function storageKey() {
-                return 'vue-table-component.' + window.location.host + window.location.pathname + this.cacheId;
+                return this.cacheKey ? 'vue-table-component.' + this.cacheKey : 'vue-table-component.' + window.location.host + window.location.pathname + this.cacheKey;
             }
         },
 
@@ -28281,7 +28294,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
             }(),
             mapDataToRows: function () {
                 var _ref3 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee3() {
-                    var _this2 = this;
+                    var _this3 = this;
 
                     var data, rowId;
                     return _regenerator2.default.wrap(function _callee3$(_context3) {
@@ -28313,7 +28326,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
                                         rowData.vueTableComponentInternalRowId = rowId++;
                                         return rowData;
                                     }).map(function (rowData) {
-                                        return new _Row2.default(rowData, _this2.columns);
+                                        return new _Row2.default(rowData, _this3.columns);
                                     });
 
                                 case 10:
@@ -28372,6 +28385,29 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 
                 return fetchServerData;
             }(),
+            refresh: function () {
+                var _ref5 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee5() {
+                    return _regenerator2.default.wrap(function _callee5$(_context5) {
+                        while (1) {
+                            switch (_context5.prev = _context5.next) {
+                                case 0:
+                                    _context5.next = 2;
+                                    return this.mapDataToRows();
+
+                                case 2:
+                                case 'end':
+                                    return _context5.stop();
+                            }
+                        }
+                    }, _callee5, this);
+                }));
+
+                function refresh() {
+                    return _ref5.apply(this, arguments);
+                }
+
+                return refresh;
+            }(),
             changeSorting: function changeSorting(column) {
                 if (this.sort.fieldName !== column.show) {
                     this.sort.fieldName = column.show;
@@ -28411,12 +28447,12 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 203 */
+/* 202 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(206)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(205)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -28462,12 +28498,12 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 204 */
+/* 203 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(32), __webpack_require__(33), __webpack_require__(79)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(32), __webpack_require__(33), __webpack_require__(77)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
@@ -28576,40 +28612,36 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 205 */
+/* 204 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(213), __webpack_require__(32), __webpack_require__(33), __webpack_require__(0), __webpack_require__(340), __webpack_require__(325)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(32), __webpack_require__(33), __webpack_require__(0), __webpack_require__(324)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
     } else if (typeof exports !== "undefined") {
-        factory(exports, require('babel-runtime/helpers/slicedToArray'), require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('moment'), require('striptags'), require('lodash/get'));
+        factory(exports, require('babel-runtime/helpers/classCallCheck'), require('babel-runtime/helpers/createClass'), require('moment'), require('lodash/get'));
     } else {
         var mod = {
             exports: {}
         };
-        factory(mod.exports, global.slicedToArray, global.classCallCheck, global.createClass, global.moment, global.striptags, global.get);
+        factory(mod.exports, global.classCallCheck, global.createClass, global.moment, global.get);
         global.Row = mod.exports;
     }
-})(this, function (exports, _slicedToArray2, _classCallCheck2, _createClass2, _moment, _striptags, _get) {
+})(this, function (exports, _classCallCheck2, _createClass2, _moment, _get) {
     'use strict';
 
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
 
-    var _slicedToArray3 = _interopRequireDefault(_slicedToArray2);
-
     var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
 
     var _createClass3 = _interopRequireDefault(_createClass2);
 
     var _moment2 = _interopRequireDefault(_moment);
-
-    var _striptags2 = _interopRequireDefault(_striptags);
 
     var _get2 = _interopRequireDefault(_get);
 
@@ -28648,7 +28680,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
                     return '';
                 }
 
-                return (0, _striptags2.default)(value.toString().toLowerCase());
+                return value.toString().toLowerCase();
             }
         }, {
             key: 'getSortableValue',
@@ -28657,15 +28689,16 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 
                 var value = this.getValue(columnName);
 
+                if (value === undefined) {
+                    return '';
+                }
+
                 if (value instanceof String) {
                     value = value.toLowerCase();
                 }
 
                 if (dataType.startsWith('date')) {
-                    var _dataType$split = dataType.split(':'),
-                        _dataType$split2 = (0, _slicedToArray3.default)(_dataType$split, 2),
-                        _ = _dataType$split2[0],
-                        format = _dataType$split2[1];
+                    var format = dataType.replace('date:', '');
 
                     return (0, _moment2.default)(value, format).format('YYYYMMDDHHmmss');
                 }
@@ -28697,7 +28730,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
-/* 206 */
+/* 205 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
@@ -28729,38 +28762,51 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
         render: function render(createElement, _ref) {
             var props = _ref.props;
 
-            var contents = props.column.template ? props.column.template(props.row.data) : props.column.formatter(props.row.getValue(props.column.show));
+            var data = {};
 
-            return createElement('td', props.column.cellClass ? { class: props.column.cellClass } : {}, contents);
+            if (props.column.cellClass) {
+                data.class = props.column.cellClass;
+            }
+
+            if (props.column.template) {
+                return createElement('td', data, props.column.template(props.row.data));
+            }
+
+            data.domProps = {};
+            data.domProps.innerHTML = props.column.formatter(props.row.getValue(props.column.show), props.row.data);
+
+            return createElement('td', data);
         }
     };
 });
 
 /***/ }),
-/* 207 */
+/* 206 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;(function (global, factory) {
     if (true) {
-        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(32), __webpack_require__(33)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
+        !(__WEBPACK_AMD_DEFINE_ARRAY__ = [exports, __webpack_require__(207), __webpack_require__(32), __webpack_require__(33)], __WEBPACK_AMD_DEFINE_FACTORY__ = (factory),
 				__WEBPACK_AMD_DEFINE_RESULT__ = (typeof __WEBPACK_AMD_DEFINE_FACTORY__ === 'function' ?
 				(__WEBPACK_AMD_DEFINE_FACTORY__.apply(exports, __WEBPACK_AMD_DEFINE_ARRAY__)) : __WEBPACK_AMD_DEFINE_FACTORY__),
 				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
     } else if (typeof exports !== "undefined") {
-        factory(exports, require("babel-runtime/helpers/classCallCheck"), require("babel-runtime/helpers/createClass"));
+        factory(exports, require("babel-runtime/core-js/json/stringify"), require("babel-runtime/helpers/classCallCheck"), require("babel-runtime/helpers/createClass"));
     } else {
         var mod = {
             exports: {}
         };
-        factory(mod.exports, global.classCallCheck, global.createClass);
+        factory(mod.exports, global.stringify, global.classCallCheck, global.createClass);
         global.expiringStorage = mod.exports;
     }
-})(this, function (exports, _classCallCheck2, _createClass2) {
+})(this, function (exports, _stringify, _classCallCheck2, _createClass2) {
     "use strict";
 
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
+
+    var _stringify2 = _interopRequireDefault(_stringify);
 
     var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
 
@@ -28807,7 +28853,7 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 
                 var expires = new Date(currentTime + lifeTimeInMinutes * 60000);
 
-                localStorage.setItem(key, JSON.stringify({ value: value, expires: expires }));
+                localStorage.setItem(key, (0, _stringify2.default)({ value: value, expires: expires }));
             }
         }]);
         return ExpiringStorage;
@@ -28817,31 +28863,31 @@ var __WEBPACK_AMD_DEFINE_FACTORY__, __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_
 });
 
 /***/ }),
+/* 207 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = { "default": __webpack_require__(213), __esModule: true };
+
+/***/ }),
 /* 208 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = { "default": __webpack_require__(215), __esModule: true };
+module.exports = { "default": __webpack_require__(214), __esModule: true };
 
 /***/ }),
 /* 209 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = { "default": __webpack_require__(216), __esModule: true };
+module.exports = { "default": __webpack_require__(215), __esModule: true };
 
 /***/ }),
 /* 210 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = { "default": __webpack_require__(217), __esModule: true };
+module.exports = { "default": __webpack_require__(216), __esModule: true };
 
 /***/ }),
 /* 211 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = { "default": __webpack_require__(218), __esModule: true };
-
-/***/ }),
-/* 212 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -28849,7 +28895,7 @@ module.exports = { "default": __webpack_require__(218), __esModule: true };
 
 exports.__esModule = true;
 
-var _promise = __webpack_require__(211);
+var _promise = __webpack_require__(210);
 
 var _promise2 = _interopRequireDefault(_promise);
 
@@ -28885,113 +28931,57 @@ exports.default = function (fn) {
 };
 
 /***/ }),
+/* 212 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(337);
+
+
+/***/ }),
 /* 213 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-
-
-exports.__esModule = true;
-
-var _isIterable2 = __webpack_require__(209);
-
-var _isIterable3 = _interopRequireDefault(_isIterable2);
-
-var _getIterator2 = __webpack_require__(208);
-
-var _getIterator3 = _interopRequireDefault(_getIterator2);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-exports.default = function () {
-  function sliceIterator(arr, i) {
-    var _arr = [];
-    var _n = true;
-    var _d = false;
-    var _e = undefined;
-
-    try {
-      for (var _i = (0, _getIterator3.default)(arr), _s; !(_n = (_s = _i.next()).done); _n = true) {
-        _arr.push(_s.value);
-
-        if (i && _arr.length === i) break;
-      }
-    } catch (err) {
-      _d = true;
-      _e = err;
-    } finally {
-      try {
-        if (!_n && _i["return"]) _i["return"]();
-      } finally {
-        if (_d) throw _e;
-      }
-    }
-
-    return _arr;
-  }
-
-  return function (arr, i) {
-    if (Array.isArray(arr)) {
-      return arr;
-    } else if ((0, _isIterable3.default)(Object(arr))) {
-      return sliceIterator(arr, i);
-    } else {
-      throw new TypeError("Invalid attempt to destructure non-iterable instance");
-    }
-  };
-}();
+var core  = __webpack_require__(3)
+  , $JSON = core.JSON || (core.JSON = {stringify: JSON.stringify});
+module.exports = function stringify(it){ // eslint-disable-line no-unused-vars
+  return $JSON.stringify.apply($JSON, arguments);
+};
 
 /***/ }),
 /* 214 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = __webpack_require__(338);
-
-
-/***/ }),
-/* 215 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(44);
-__webpack_require__(43);
-module.exports = __webpack_require__(245);
-
-/***/ }),
-/* 216 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(44);
-__webpack_require__(43);
-module.exports = __webpack_require__(246);
-
-/***/ }),
-/* 217 */
-/***/ (function(module, exports, __webpack_require__) {
-
-__webpack_require__(248);
-var $Object = __webpack_require__(5).Object;
+__webpack_require__(244);
+var $Object = __webpack_require__(3).Object;
 module.exports = function defineProperty(it, key, desc){
   return $Object.defineProperty(it, key, desc);
 };
 
 /***/ }),
-/* 218 */
+/* 215 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(249);
-__webpack_require__(43);
-__webpack_require__(44);
-__webpack_require__(250);
-module.exports = __webpack_require__(5).Promise;
+__webpack_require__(245);
+module.exports = __webpack_require__(3).Object.keys;
 
 /***/ }),
-/* 219 */
+/* 216 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(246);
+__webpack_require__(248);
+__webpack_require__(249);
+__webpack_require__(247);
+module.exports = __webpack_require__(3).Promise;
+
+/***/ }),
+/* 217 */
 /***/ (function(module, exports) {
 
 module.exports = function(){ /* empty */ };
 
 /***/ }),
-/* 220 */
+/* 218 */
 /***/ (function(module, exports) {
 
 module.exports = function(it, Constructor, name, forbiddenField){
@@ -29001,14 +28991,14 @@ module.exports = function(it, Constructor, name, forbiddenField){
 };
 
 /***/ }),
-/* 221 */
+/* 219 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // false -> Array#indexOf
 // true  -> Array#includes
-var toIObject = __webpack_require__(42)
-  , toLength  = __webpack_require__(60)
-  , toIndex   = __webpack_require__(242);
+var toIObject = __webpack_require__(41)
+  , toLength  = __webpack_require__(58)
+  , toIndex   = __webpack_require__(240);
 module.exports = function(IS_INCLUDES){
   return function($this, el, fromIndex){
     var O      = toIObject($this)
@@ -29027,15 +29017,15 @@ module.exports = function(IS_INCLUDES){
 };
 
 /***/ }),
-/* 222 */
+/* 220 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ctx         = __webpack_require__(16)
-  , call        = __webpack_require__(227)
-  , isArrayIter = __webpack_require__(226)
+  , call        = __webpack_require__(225)
+  , isArrayIter = __webpack_require__(224)
   , anObject    = __webpack_require__(6)
-  , toLength    = __webpack_require__(60)
-  , getIterFn   = __webpack_require__(62)
+  , toLength    = __webpack_require__(58)
+  , getIterFn   = __webpack_require__(242)
   , BREAK       = {}
   , RETURN      = {};
 var exports = module.exports = function(iterable, entries, fn, that, ITERATOR){
@@ -29057,15 +29047,15 @@ exports.BREAK  = BREAK;
 exports.RETURN = RETURN;
 
 /***/ }),
-/* 223 */
+/* 221 */
 /***/ (function(module, exports, __webpack_require__) {
 
-module.exports = !__webpack_require__(7) && !__webpack_require__(53)(function(){
-  return Object.defineProperty(__webpack_require__(37)('div'), 'a', {get: function(){ return 7; }}).a != 7;
+module.exports = !__webpack_require__(7) && !__webpack_require__(37)(function(){
+  return Object.defineProperty(__webpack_require__(36)('div'), 'a', {get: function(){ return 7; }}).a != 7;
 });
 
 /***/ }),
-/* 224 */
+/* 222 */
 /***/ (function(module, exports) {
 
 // fast apply, http://jsperf.lnkit.com/fast-apply/5
@@ -29086,7 +29076,7 @@ module.exports = function(fn, args, that){
 };
 
 /***/ }),
-/* 225 */
+/* 223 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // fallback for non-array-like ES3 and non-enumerable old V8 strings
@@ -29096,11 +29086,11 @@ module.exports = Object('z').propertyIsEnumerable(0) ? Object : function(it){
 };
 
 /***/ }),
-/* 226 */
+/* 224 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // check on default Array iterator
-var Iterators  = __webpack_require__(9)
+var Iterators  = __webpack_require__(11)
   , ITERATOR   = __webpack_require__(1)('iterator')
   , ArrayProto = Array.prototype;
 
@@ -29109,7 +29099,7 @@ module.exports = function(it){
 };
 
 /***/ }),
-/* 227 */
+/* 225 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // call something on iterator step with safe closing on error
@@ -29126,14 +29116,14 @@ module.exports = function(iterator, fn, value, entries){
 };
 
 /***/ }),
-/* 228 */
+/* 226 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var create         = __webpack_require__(232)
-  , descriptor     = __webpack_require__(57)
-  , setToStringTag = __webpack_require__(39)
+var create         = __webpack_require__(230)
+  , descriptor     = __webpack_require__(55)
+  , setToStringTag = __webpack_require__(38)
   , IteratorPrototype = {};
 
 // 25.1.2.1.1 %IteratorPrototype%[@@iterator]()
@@ -29145,7 +29135,7 @@ module.exports = function(Constructor, NAME, next){
 };
 
 /***/ }),
-/* 229 */
+/* 227 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var ITERATOR     = __webpack_require__(1)('iterator')
@@ -29171,7 +29161,7 @@ module.exports = function(exec, skipClosing){
 };
 
 /***/ }),
-/* 230 */
+/* 228 */
 /***/ (function(module, exports) {
 
 module.exports = function(done, value){
@@ -29179,11 +29169,11 @@ module.exports = function(done, value){
 };
 
 /***/ }),
-/* 231 */
+/* 229 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var global    = __webpack_require__(2)
-  , macrotask = __webpack_require__(59).set
+  , macrotask = __webpack_require__(57).set
   , Observer  = global.MutationObserver || global.WebKitMutationObserver
   , process   = global.process
   , Promise   = global.Promise
@@ -29252,27 +29242,27 @@ module.exports = function(){
 };
 
 /***/ }),
-/* 232 */
+/* 230 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
 var anObject    = __webpack_require__(6)
-  , dPs         = __webpack_require__(233)
-  , enumBugKeys = __webpack_require__(52)
-  , IE_PROTO    = __webpack_require__(40)('IE_PROTO')
+  , dPs         = __webpack_require__(231)
+  , enumBugKeys = __webpack_require__(50)
+  , IE_PROTO    = __webpack_require__(39)('IE_PROTO')
   , Empty       = function(){ /* empty */ }
   , PROTOTYPE   = 'prototype';
 
 // Create object with fake `null` prototype: use iframe Object with cleared prototype
 var createDict = function(){
   // Thrash, waste and sodomy: IE GC bug
-  var iframe = __webpack_require__(37)('iframe')
+  var iframe = __webpack_require__(36)('iframe')
     , i      = enumBugKeys.length
     , lt     = '<'
     , gt     = '>'
     , iframeDocument;
   iframe.style.display = 'none';
-  __webpack_require__(54).appendChild(iframe);
+  __webpack_require__(51).appendChild(iframe);
   iframe.src = 'javascript:'; // eslint-disable-line no-script-url
   // createDict = iframe.contentWindow.Object;
   // html.removeChild(iframe);
@@ -29299,12 +29289,12 @@ module.exports = Object.create || function create(O, Properties){
 
 
 /***/ }),
-/* 233 */
+/* 231 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var dP       = __webpack_require__(12)
   , anObject = __webpack_require__(6)
-  , getKeys  = __webpack_require__(236);
+  , getKeys  = __webpack_require__(54);
 
 module.exports = __webpack_require__(7) ? Object.defineProperties : function defineProperties(O, Properties){
   anObject(O);
@@ -29317,13 +29307,13 @@ module.exports = __webpack_require__(7) ? Object.defineProperties : function def
 };
 
 /***/ }),
-/* 234 */
+/* 232 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 19.1.2.9 / 15.2.3.2 Object.getPrototypeOf(O)
-var has         = __webpack_require__(17)
-  , toObject    = __webpack_require__(243)
-  , IE_PROTO    = __webpack_require__(40)('IE_PROTO')
+var has         = __webpack_require__(18)
+  , toObject    = __webpack_require__(59)
+  , IE_PROTO    = __webpack_require__(39)('IE_PROTO')
   , ObjectProto = Object.prototype;
 
 module.exports = Object.getPrototypeOf || function(O){
@@ -29335,13 +29325,13 @@ module.exports = Object.getPrototypeOf || function(O){
 };
 
 /***/ }),
-/* 235 */
+/* 233 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var has          = __webpack_require__(17)
-  , toIObject    = __webpack_require__(42)
-  , arrayIndexOf = __webpack_require__(221)(false)
-  , IE_PROTO     = __webpack_require__(40)('IE_PROTO');
+var has          = __webpack_require__(18)
+  , toIObject    = __webpack_require__(41)
+  , arrayIndexOf = __webpack_require__(219)(false)
+  , IE_PROTO     = __webpack_require__(39)('IE_PROTO');
 
 module.exports = function(object, names){
   var O      = toIObject(object)
@@ -29357,19 +29347,22 @@ module.exports = function(object, names){
 };
 
 /***/ }),
-/* 236 */
+/* 234 */
 /***/ (function(module, exports, __webpack_require__) {
 
-// 19.1.2.14 / 15.2.3.14 Object.keys(O)
-var $keys       = __webpack_require__(235)
-  , enumBugKeys = __webpack_require__(52);
-
-module.exports = Object.keys || function keys(O){
-  return $keys(O, enumBugKeys);
+// most Object methods by ES6 should accept primitives
+var $export = __webpack_require__(17)
+  , core    = __webpack_require__(3)
+  , fails   = __webpack_require__(37);
+module.exports = function(KEY, exec){
+  var fn  = (core.Object || {})[KEY] || Object[KEY]
+    , exp = {};
+  exp[KEY] = exec(fn);
+  $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
 };
 
 /***/ }),
-/* 237 */
+/* 235 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var hide = __webpack_require__(8);
@@ -29381,19 +29374,19 @@ module.exports = function(target, src, safe){
 };
 
 /***/ }),
-/* 238 */
+/* 236 */
 /***/ (function(module, exports, __webpack_require__) {
 
 module.exports = __webpack_require__(8);
 
 /***/ }),
-/* 239 */
+/* 237 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
 var global      = __webpack_require__(2)
-  , core        = __webpack_require__(5)
+  , core        = __webpack_require__(3)
   , dP          = __webpack_require__(12)
   , DESCRIPTORS = __webpack_require__(7)
   , SPECIES     = __webpack_require__(1)('species');
@@ -29407,7 +29400,7 @@ module.exports = function(KEY){
 };
 
 /***/ }),
-/* 240 */
+/* 238 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.3.20 SpeciesConstructor(O, defaultConstructor)
@@ -29420,11 +29413,11 @@ module.exports = function(O, D){
 };
 
 /***/ }),
-/* 241 */
+/* 239 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(41)
-  , defined   = __webpack_require__(36);
+var toInteger = __webpack_require__(40)
+  , defined   = __webpack_require__(35);
 // true  -> String#at
 // false -> String#codePointAt
 module.exports = function(TO_STRING){
@@ -29442,10 +29435,10 @@ module.exports = function(TO_STRING){
 };
 
 /***/ }),
-/* 242 */
+/* 240 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toInteger = __webpack_require__(41)
+var toInteger = __webpack_require__(40)
   , max       = Math.max
   , min       = Math.min;
 module.exports = function(index, length){
@@ -29454,21 +29447,11 @@ module.exports = function(index, length){
 };
 
 /***/ }),
-/* 243 */
-/***/ (function(module, exports, __webpack_require__) {
-
-// 7.1.13 ToObject(argument)
-var defined = __webpack_require__(36);
-module.exports = function(it){
-  return Object(defined(it));
-};
-
-/***/ }),
-/* 244 */
+/* 241 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // 7.1.1 ToPrimitive(input [, PreferredType])
-var isObject = __webpack_require__(18);
+var isObject = __webpack_require__(19);
 // instead of the ES6 spec version, we didn't implement @@toPrimitive case
 // and the second argument - flag - preferred type is a string
 module.exports = function(it, S){
@@ -29481,47 +29464,34 @@ module.exports = function(it, S){
 };
 
 /***/ }),
-/* 245 */
+/* 242 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var anObject = __webpack_require__(6)
-  , get      = __webpack_require__(62);
-module.exports = __webpack_require__(5).getIterator = function(it){
-  var iterFn = get(it);
-  if(typeof iterFn != 'function')throw TypeError(it + ' is not iterable!');
-  return anObject(iterFn.call(it));
-};
-
-/***/ }),
-/* 246 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var classof   = __webpack_require__(35)
+var classof   = __webpack_require__(49)
   , ITERATOR  = __webpack_require__(1)('iterator')
-  , Iterators = __webpack_require__(9);
-module.exports = __webpack_require__(5).isIterable = function(it){
-  var O = Object(it);
-  return O[ITERATOR] !== undefined
-    || '@@iterator' in O
-    || Iterators.hasOwnProperty(classof(O));
+  , Iterators = __webpack_require__(11);
+module.exports = __webpack_require__(3).getIteratorMethod = function(it){
+  if(it != undefined)return it[ITERATOR]
+    || it['@@iterator']
+    || Iterators[classof(it)];
 };
 
 /***/ }),
-/* 247 */
+/* 243 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var addToUnscopables = __webpack_require__(219)
-  , step             = __webpack_require__(230)
-  , Iterators        = __webpack_require__(9)
-  , toIObject        = __webpack_require__(42);
+var addToUnscopables = __webpack_require__(217)
+  , step             = __webpack_require__(228)
+  , Iterators        = __webpack_require__(11)
+  , toIObject        = __webpack_require__(41);
 
 // 22.1.3.4 Array.prototype.entries()
 // 22.1.3.13 Array.prototype.keys()
 // 22.1.3.29 Array.prototype.values()
 // 22.1.3.30 Array.prototype[@@iterator]()
-module.exports = __webpack_require__(55)(Array, 'Array', function(iterated, kind){
+module.exports = __webpack_require__(52)(Array, 'Array', function(iterated, kind){
   this._t = toIObject(iterated); // target
   this._i = 0;                   // next index
   this._k = kind;                // kind
@@ -29547,37 +29517,51 @@ addToUnscopables('values');
 addToUnscopables('entries');
 
 /***/ }),
-/* 248 */
+/* 244 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var $export = __webpack_require__(38);
+var $export = __webpack_require__(17);
 // 19.1.2.4 / 15.2.3.6 Object.defineProperty(O, P, Attributes)
 $export($export.S + $export.F * !__webpack_require__(7), 'Object', {defineProperty: __webpack_require__(12).f});
 
 /***/ }),
-/* 249 */
+/* 245 */
+/***/ (function(module, exports, __webpack_require__) {
+
+// 19.1.2.14 Object.keys(O)
+var toObject = __webpack_require__(59)
+  , $keys    = __webpack_require__(54);
+
+__webpack_require__(234)('keys', function(){
+  return function keys(it){
+    return $keys(toObject(it));
+  };
+});
+
+/***/ }),
+/* 246 */
 /***/ (function(module, exports) {
 
 
 
 /***/ }),
-/* 250 */
+/* 247 */
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
 
-var LIBRARY            = __webpack_require__(56)
+var LIBRARY            = __webpack_require__(53)
   , global             = __webpack_require__(2)
   , ctx                = __webpack_require__(16)
-  , classof            = __webpack_require__(35)
-  , $export            = __webpack_require__(38)
-  , isObject           = __webpack_require__(18)
+  , classof            = __webpack_require__(49)
+  , $export            = __webpack_require__(17)
+  , isObject           = __webpack_require__(19)
   , aFunction          = __webpack_require__(34)
-  , anInstance         = __webpack_require__(220)
-  , forOf              = __webpack_require__(222)
-  , speciesConstructor = __webpack_require__(240)
-  , task               = __webpack_require__(59).set
-  , microtask          = __webpack_require__(231)()
+  , anInstance         = __webpack_require__(218)
+  , forOf              = __webpack_require__(220)
+  , speciesConstructor = __webpack_require__(238)
+  , task               = __webpack_require__(57).set
+  , microtask          = __webpack_require__(229)()
   , PROMISE            = 'Promise'
   , TypeError          = global.TypeError
   , process            = global.process
@@ -29769,7 +29753,7 @@ if(!USE_NATIVE){
     this._h = 0;              // <- rejection state, 0 - default, 1 - handled, 2 - unhandled
     this._n = false;          // <- notify
   };
-  Internal.prototype = __webpack_require__(237)($Promise.prototype, {
+  Internal.prototype = __webpack_require__(235)($Promise.prototype, {
     // 25.4.5.3 Promise.prototype.then(onFulfilled, onRejected)
     then: function then(onFulfilled, onRejected){
       var reaction    = newPromiseCapability(speciesConstructor(this, $Promise));
@@ -29795,9 +29779,9 @@ if(!USE_NATIVE){
 }
 
 $export($export.G + $export.W + $export.F * !USE_NATIVE, {Promise: $Promise});
-__webpack_require__(39)($Promise, PROMISE);
-__webpack_require__(239)(PROMISE);
-Wrapper = __webpack_require__(5)[PROMISE];
+__webpack_require__(38)($Promise, PROMISE);
+__webpack_require__(237)(PROMISE);
+Wrapper = __webpack_require__(3)[PROMISE];
 
 // statics
 $export($export.S + $export.F * !USE_NATIVE, PROMISE, {
@@ -29820,7 +29804,7 @@ $export($export.S + $export.F * (LIBRARY || !USE_NATIVE), PROMISE, {
     return capability.promise;
   }
 });
-$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(229)(function(iter){
+$export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(227)(function(iter){
   $Promise.all(iter)['catch'](empty);
 })), PROMISE, {
   // 25.4.4.1 Promise.all(iterable)
@@ -29866,14 +29850,55 @@ $export($export.S + $export.F * !(USE_NATIVE && __webpack_require__(229)(functio
 });
 
 /***/ }),
-/* 251 */
+/* 248 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var hashClear = __webpack_require__(290),
-    hashDelete = __webpack_require__(291),
-    hashGet = __webpack_require__(292),
-    hashHas = __webpack_require__(293),
-    hashSet = __webpack_require__(294);
+"use strict";
+
+var $at  = __webpack_require__(239)(true);
+
+// 21.1.3.27 String.prototype[@@iterator]()
+__webpack_require__(52)(String, 'String', function(iterated){
+  this._t = String(iterated); // target
+  this._i = 0;                // next index
+// 21.1.5.2.1 %StringIteratorPrototype%.next()
+}, function(){
+  var O     = this._t
+    , index = this._i
+    , point;
+  if(index >= O.length)return {value: undefined, done: true};
+  point = $at(O, index);
+  this._i += point.length;
+  return {value: point, done: false};
+});
+
+/***/ }),
+/* 249 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(243);
+var global        = __webpack_require__(2)
+  , hide          = __webpack_require__(8)
+  , Iterators     = __webpack_require__(11)
+  , TO_STRING_TAG = __webpack_require__(1)('toStringTag');
+
+for(var collections = ['NodeList', 'DOMTokenList', 'MediaList', 'StyleSheetList', 'CSSRuleList'], i = 0; i < 5; i++){
+  var NAME       = collections[i]
+    , Collection = global[NAME]
+    , proto      = Collection && Collection.prototype;
+  if(proto && !proto[TO_STRING_TAG])hide(proto, TO_STRING_TAG, NAME);
+  Iterators[NAME] = Iterators.Array;
+}
+
+/***/ }),
+/* 250 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var hashClear = __webpack_require__(289),
+    hashDelete = __webpack_require__(290),
+    hashGet = __webpack_require__(291),
+    hashHas = __webpack_require__(292),
+    hashSet = __webpack_require__(293);
 
 /**
  * Creates a hash object.
@@ -29904,15 +29929,15 @@ module.exports = Hash;
 
 
 /***/ }),
-/* 252 */
+/* 251 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var ListCache = __webpack_require__(19),
-    stackClear = __webpack_require__(316),
-    stackDelete = __webpack_require__(317),
-    stackGet = __webpack_require__(318),
-    stackHas = __webpack_require__(319),
-    stackSet = __webpack_require__(320);
+var ListCache = __webpack_require__(20),
+    stackClear = __webpack_require__(315),
+    stackDelete = __webpack_require__(316),
+    stackGet = __webpack_require__(317),
+    stackHas = __webpack_require__(318),
+    stackSet = __webpack_require__(319);
 
 /**
  * Creates a stack cache object to store key-value pairs.
@@ -29937,10 +29962,10 @@ module.exports = Stack;
 
 
 /***/ }),
-/* 253 */
+/* 252 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var root = __webpack_require__(10);
+var root = __webpack_require__(9);
 
 /** Built-in value references. */
 var Uint8Array = root.Uint8Array;
@@ -29949,7 +29974,7 @@ module.exports = Uint8Array;
 
 
 /***/ }),
-/* 254 */
+/* 253 */
 /***/ (function(module, exports) {
 
 /**
@@ -29976,15 +30001,15 @@ module.exports = apply;
 
 
 /***/ }),
-/* 255 */
+/* 254 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseTimes = __webpack_require__(274),
-    isArguments = __webpack_require__(27),
-    isArray = __webpack_require__(3),
-    isBuffer = __webpack_require__(76),
-    isIndex = __webpack_require__(24),
-    isTypedArray = __webpack_require__(77);
+var baseTimes = __webpack_require__(273),
+    isArguments = __webpack_require__(28),
+    isArray = __webpack_require__(4),
+    isBuffer = __webpack_require__(74),
+    isIndex = __webpack_require__(25),
+    isTypedArray = __webpack_require__(75);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -30031,7 +30056,7 @@ module.exports = arrayLikeKeys;
 
 
 /***/ }),
-/* 256 */
+/* 255 */
 /***/ (function(module, exports) {
 
 /**
@@ -30058,7 +30083,7 @@ module.exports = arrayMap;
 
 
 /***/ }),
-/* 257 */
+/* 256 */
 /***/ (function(module, exports) {
 
 /**
@@ -30084,10 +30109,10 @@ module.exports = arrayPush;
 
 
 /***/ }),
-/* 258 */
+/* 257 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(4);
+var isObject = __webpack_require__(5);
 
 /** Built-in value references. */
 var objectCreate = Object.create;
@@ -30120,11 +30145,11 @@ module.exports = baseCreate;
 
 
 /***/ }),
-/* 259 */
+/* 258 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var arrayPush = __webpack_require__(257),
-    isFlattenable = __webpack_require__(296);
+var arrayPush = __webpack_require__(256),
+    isFlattenable = __webpack_require__(295);
 
 /**
  * The base implementation of `_.flatten` with support for restricting flattening.
@@ -30164,10 +30189,10 @@ module.exports = baseFlatten;
 
 
 /***/ }),
-/* 260 */
+/* 259 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var createBaseFor = __webpack_require__(284);
+var createBaseFor = __webpack_require__(283);
 
 /**
  * The base implementation of `baseForOwn` which iterates over `object`
@@ -30186,7 +30211,7 @@ module.exports = baseFor;
 
 
 /***/ }),
-/* 261 */
+/* 260 */
 /***/ (function(module, exports) {
 
 /**
@@ -30205,11 +30230,11 @@ module.exports = baseHasIn;
 
 
 /***/ }),
-/* 262 */
+/* 261 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var baseGetTag = __webpack_require__(13),
-    isObjectLike = __webpack_require__(11);
+    isObjectLike = __webpack_require__(10);
 
 /** `Object#toString` result references. */
 var argsTag = '[object Arguments]';
@@ -30229,13 +30254,13 @@ module.exports = baseIsArguments;
 
 
 /***/ }),
-/* 263 */
+/* 262 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isFunction = __webpack_require__(49),
-    isMasked = __webpack_require__(299),
-    isObject = __webpack_require__(4),
-    toSource = __webpack_require__(322);
+var isFunction = __webpack_require__(46),
+    isMasked = __webpack_require__(298),
+    isObject = __webpack_require__(5),
+    toSource = __webpack_require__(321);
 
 /**
  * Used to match `RegExp`
@@ -30282,12 +30307,12 @@ module.exports = baseIsNative;
 
 
 /***/ }),
-/* 264 */
+/* 263 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var baseGetTag = __webpack_require__(13),
-    isLength = __webpack_require__(50),
-    isObjectLike = __webpack_require__(11);
+    isLength = __webpack_require__(47),
+    isObjectLike = __webpack_require__(10);
 
 /** `Object#toString` result references. */
 var argsTag = '[object Arguments]',
@@ -30348,12 +30373,12 @@ module.exports = baseIsTypedArray;
 
 
 /***/ }),
-/* 265 */
+/* 264 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(4),
-    isPrototype = __webpack_require__(72),
-    nativeKeysIn = __webpack_require__(311);
+var isObject = __webpack_require__(5),
+    isPrototype = __webpack_require__(70),
+    nativeKeysIn = __webpack_require__(310);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -30387,15 +30412,15 @@ module.exports = baseKeysIn;
 
 
 /***/ }),
-/* 266 */
+/* 265 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Stack = __webpack_require__(252),
-    assignMergeValue = __webpack_require__(65),
-    baseFor = __webpack_require__(260),
-    baseMergeDeep = __webpack_require__(267),
-    isObject = __webpack_require__(4),
-    keysIn = __webpack_require__(78);
+var Stack = __webpack_require__(251),
+    assignMergeValue = __webpack_require__(63),
+    baseFor = __webpack_require__(259),
+    baseMergeDeep = __webpack_require__(266),
+    isObject = __webpack_require__(5),
+    keysIn = __webpack_require__(76);
 
 /**
  * The base implementation of `_.merge` without support for multiple sources.
@@ -30434,23 +30459,23 @@ module.exports = baseMerge;
 
 
 /***/ }),
-/* 267 */
+/* 266 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assignMergeValue = __webpack_require__(65),
-    cloneBuffer = __webpack_require__(278),
-    cloneTypedArray = __webpack_require__(279),
-    copyArray = __webpack_require__(280),
-    initCloneObject = __webpack_require__(295),
-    isArguments = __webpack_require__(27),
-    isArray = __webpack_require__(3),
-    isArrayLikeObject = __webpack_require__(327),
-    isBuffer = __webpack_require__(76),
-    isFunction = __webpack_require__(49),
-    isObject = __webpack_require__(4),
-    isPlainObject = __webpack_require__(328),
-    isTypedArray = __webpack_require__(77),
-    toPlainObject = __webpack_require__(335);
+var assignMergeValue = __webpack_require__(63),
+    cloneBuffer = __webpack_require__(277),
+    cloneTypedArray = __webpack_require__(278),
+    copyArray = __webpack_require__(279),
+    initCloneObject = __webpack_require__(294),
+    isArguments = __webpack_require__(28),
+    isArray = __webpack_require__(4),
+    isArrayLikeObject = __webpack_require__(326),
+    isBuffer = __webpack_require__(74),
+    isFunction = __webpack_require__(46),
+    isObject = __webpack_require__(5),
+    isPlainObject = __webpack_require__(327),
+    isTypedArray = __webpack_require__(75),
+    toPlainObject = __webpack_require__(334);
 
 /**
  * A specialized version of `baseMerge` for arrays and objects which performs
@@ -30533,11 +30558,11 @@ module.exports = baseMergeDeep;
 
 
 /***/ }),
-/* 268 */
+/* 267 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var basePickBy = __webpack_require__(269),
-    hasIn = __webpack_require__(326);
+var basePickBy = __webpack_require__(268),
+    hasIn = __webpack_require__(325);
 
 /**
  * The base implementation of `_.pick` without support for individual
@@ -30558,12 +30583,12 @@ module.exports = basePick;
 
 
 /***/ }),
-/* 269 */
+/* 268 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseGet = __webpack_require__(67),
-    baseSet = __webpack_require__(272),
-    castPath = __webpack_require__(22);
+var baseGet = __webpack_require__(65),
+    baseSet = __webpack_require__(271),
+    castPath = __webpack_require__(23);
 
 /**
  * The base implementation of  `_.pickBy` without support for iteratee shorthands.
@@ -30594,7 +30619,7 @@ module.exports = basePickBy;
 
 
 /***/ }),
-/* 270 */
+/* 269 */
 /***/ (function(module, exports) {
 
 /* Built-in method references for those with the same name as other `lodash` methods. */
@@ -30628,12 +30653,12 @@ module.exports = baseRange;
 
 
 /***/ }),
-/* 271 */
+/* 270 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var identity = __webpack_require__(75),
-    overRest = __webpack_require__(73),
-    setToString = __webpack_require__(74);
+var identity = __webpack_require__(73),
+    overRest = __webpack_require__(71),
+    setToString = __webpack_require__(72);
 
 /**
  * The base implementation of `_.rest` which doesn't validate or coerce arguments.
@@ -30651,14 +30676,14 @@ module.exports = baseRest;
 
 
 /***/ }),
-/* 272 */
+/* 271 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assignValue = __webpack_require__(66),
-    castPath = __webpack_require__(22),
-    isIndex = __webpack_require__(24),
-    isObject = __webpack_require__(4),
-    toKey = __webpack_require__(47);
+var assignValue = __webpack_require__(64),
+    castPath = __webpack_require__(23),
+    isIndex = __webpack_require__(25),
+    isObject = __webpack_require__(5),
+    toKey = __webpack_require__(44);
 
 /**
  * The base implementation of `_.set`.
@@ -30704,12 +30729,12 @@ module.exports = baseSet;
 
 
 /***/ }),
-/* 273 */
+/* 272 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var constant = __webpack_require__(323),
-    defineProperty = __webpack_require__(68),
-    identity = __webpack_require__(75);
+var constant = __webpack_require__(322),
+    defineProperty = __webpack_require__(66),
+    identity = __webpack_require__(73);
 
 /**
  * The base implementation of `setToString` without support for hot loop shorting.
@@ -30732,7 +30757,7 @@ module.exports = baseSetToString;
 
 
 /***/ }),
-/* 274 */
+/* 273 */
 /***/ (function(module, exports) {
 
 /**
@@ -30758,13 +30783,13 @@ module.exports = baseTimes;
 
 
 /***/ }),
-/* 275 */
+/* 274 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Symbol = __webpack_require__(20),
-    arrayMap = __webpack_require__(256),
-    isArray = __webpack_require__(3),
-    isSymbol = __webpack_require__(28);
+var Symbol = __webpack_require__(21),
+    arrayMap = __webpack_require__(255),
+    isArray = __webpack_require__(4),
+    isSymbol = __webpack_require__(29);
 
 /** Used as references for various `Number` constants. */
 var INFINITY = 1 / 0;
@@ -30801,7 +30826,7 @@ module.exports = baseToString;
 
 
 /***/ }),
-/* 276 */
+/* 275 */
 /***/ (function(module, exports) {
 
 /**
@@ -30821,10 +30846,10 @@ module.exports = baseUnary;
 
 
 /***/ }),
-/* 277 */
+/* 276 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Uint8Array = __webpack_require__(253);
+var Uint8Array = __webpack_require__(252);
 
 /**
  * Creates a clone of `arrayBuffer`.
@@ -30843,10 +30868,10 @@ module.exports = cloneArrayBuffer;
 
 
 /***/ }),
-/* 278 */
+/* 277 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(10);
+/* WEBPACK VAR INJECTION */(function(module) {var root = __webpack_require__(9);
 
 /** Detect free variable `exports`. */
 var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -30885,10 +30910,10 @@ module.exports = cloneBuffer;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(30)(module)))
 
 /***/ }),
-/* 279 */
+/* 278 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var cloneArrayBuffer = __webpack_require__(277);
+var cloneArrayBuffer = __webpack_require__(276);
 
 /**
  * Creates a clone of `typedArray`.
@@ -30907,7 +30932,7 @@ module.exports = cloneTypedArray;
 
 
 /***/ }),
-/* 280 */
+/* 279 */
 /***/ (function(module, exports) {
 
 /**
@@ -30933,11 +30958,11 @@ module.exports = copyArray;
 
 
 /***/ }),
-/* 281 */
+/* 280 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assignValue = __webpack_require__(66),
-    baseAssignValue = __webpack_require__(45);
+var assignValue = __webpack_require__(64),
+    baseAssignValue = __webpack_require__(42);
 
 /**
  * Copies properties of `source` to `object`.
@@ -30979,10 +31004,10 @@ module.exports = copyObject;
 
 
 /***/ }),
-/* 282 */
+/* 281 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var root = __webpack_require__(10);
+var root = __webpack_require__(9);
 
 /** Used to detect overreaching core-js shims. */
 var coreJsData = root['__core-js_shared__'];
@@ -30991,11 +31016,11 @@ module.exports = coreJsData;
 
 
 /***/ }),
-/* 283 */
+/* 282 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseRest = __webpack_require__(271),
-    isIterateeCall = __webpack_require__(71);
+var baseRest = __webpack_require__(270),
+    isIterateeCall = __webpack_require__(69);
 
 /**
  * Creates a function like `_.assign`.
@@ -31034,7 +31059,7 @@ module.exports = createAssigner;
 
 
 /***/ }),
-/* 284 */
+/* 283 */
 /***/ (function(module, exports) {
 
 /**
@@ -31065,12 +31090,12 @@ module.exports = createBaseFor;
 
 
 /***/ }),
-/* 285 */
+/* 284 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseRange = __webpack_require__(270),
-    isIterateeCall = __webpack_require__(71),
-    toFinite = __webpack_require__(333);
+var baseRange = __webpack_require__(269),
+    isIterateeCall = __webpack_require__(69),
+    toFinite = __webpack_require__(332);
 
 /**
  * Creates a `_.range` or `_.rangeRight` function.
@@ -31101,12 +31126,12 @@ module.exports = createRange;
 
 
 /***/ }),
-/* 286 */
+/* 285 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var flatten = __webpack_require__(324),
-    overRest = __webpack_require__(73),
-    setToString = __webpack_require__(74);
+var flatten = __webpack_require__(323),
+    overRest = __webpack_require__(71),
+    setToString = __webpack_require__(72);
 
 /**
  * A specialized version of `baseRest` which flattens the rest array.
@@ -31123,10 +31148,10 @@ module.exports = flatRest;
 
 
 /***/ }),
-/* 287 */
+/* 286 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Symbol = __webpack_require__(20);
+var Symbol = __webpack_require__(21);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -31175,7 +31200,7 @@ module.exports = getRawTag;
 
 
 /***/ }),
-/* 288 */
+/* 287 */
 /***/ (function(module, exports) {
 
 /**
@@ -31194,15 +31219,15 @@ module.exports = getValue;
 
 
 /***/ }),
-/* 289 */
+/* 288 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var castPath = __webpack_require__(22),
-    isArguments = __webpack_require__(27),
-    isArray = __webpack_require__(3),
-    isIndex = __webpack_require__(24),
-    isLength = __webpack_require__(50),
-    toKey = __webpack_require__(47);
+var castPath = __webpack_require__(23),
+    isArguments = __webpack_require__(28),
+    isArray = __webpack_require__(4),
+    isIndex = __webpack_require__(25),
+    isLength = __webpack_require__(47),
+    toKey = __webpack_require__(44);
 
 /**
  * Checks if `path` exists on `object`.
@@ -31239,10 +31264,10 @@ module.exports = hasPath;
 
 
 /***/ }),
-/* 290 */
+/* 289 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var nativeCreate = __webpack_require__(25);
+var nativeCreate = __webpack_require__(26);
 
 /**
  * Removes all key-value entries from the hash.
@@ -31260,7 +31285,7 @@ module.exports = hashClear;
 
 
 /***/ }),
-/* 291 */
+/* 290 */
 /***/ (function(module, exports) {
 
 /**
@@ -31283,10 +31308,10 @@ module.exports = hashDelete;
 
 
 /***/ }),
-/* 292 */
+/* 291 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var nativeCreate = __webpack_require__(25);
+var nativeCreate = __webpack_require__(26);
 
 /** Used to stand-in for `undefined` hash values. */
 var HASH_UNDEFINED = '__lodash_hash_undefined__';
@@ -31319,10 +31344,10 @@ module.exports = hashGet;
 
 
 /***/ }),
-/* 293 */
+/* 292 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var nativeCreate = __webpack_require__(25);
+var nativeCreate = __webpack_require__(26);
 
 /** Used for built-in method references. */
 var objectProto = Object.prototype;
@@ -31348,10 +31373,10 @@ module.exports = hashHas;
 
 
 /***/ }),
-/* 294 */
+/* 293 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var nativeCreate = __webpack_require__(25);
+var nativeCreate = __webpack_require__(26);
 
 /** Used to stand-in for `undefined` hash values. */
 var HASH_UNDEFINED = '__lodash_hash_undefined__';
@@ -31377,12 +31402,12 @@ module.exports = hashSet;
 
 
 /***/ }),
-/* 295 */
+/* 294 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseCreate = __webpack_require__(258),
-    getPrototype = __webpack_require__(70),
-    isPrototype = __webpack_require__(72);
+var baseCreate = __webpack_require__(257),
+    getPrototype = __webpack_require__(68),
+    isPrototype = __webpack_require__(70);
 
 /**
  * Initializes an object clone.
@@ -31401,12 +31426,12 @@ module.exports = initCloneObject;
 
 
 /***/ }),
-/* 296 */
+/* 295 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Symbol = __webpack_require__(20),
-    isArguments = __webpack_require__(27),
-    isArray = __webpack_require__(3);
+var Symbol = __webpack_require__(21),
+    isArguments = __webpack_require__(28),
+    isArray = __webpack_require__(4);
 
 /** Built-in value references. */
 var spreadableSymbol = Symbol ? Symbol.isConcatSpreadable : undefined;
@@ -31427,11 +31452,11 @@ module.exports = isFlattenable;
 
 
 /***/ }),
-/* 297 */
+/* 296 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isArray = __webpack_require__(3),
-    isSymbol = __webpack_require__(28);
+var isArray = __webpack_require__(4),
+    isSymbol = __webpack_require__(29);
 
 /** Used to match property names within property paths. */
 var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
@@ -31462,7 +31487,7 @@ module.exports = isKey;
 
 
 /***/ }),
-/* 298 */
+/* 297 */
 /***/ (function(module, exports) {
 
 /**
@@ -31483,10 +31508,10 @@ module.exports = isKeyable;
 
 
 /***/ }),
-/* 299 */
+/* 298 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var coreJsData = __webpack_require__(282);
+var coreJsData = __webpack_require__(281);
 
 /** Used to detect methods masquerading as native. */
 var maskSrcKey = (function() {
@@ -31509,7 +31534,7 @@ module.exports = isMasked;
 
 
 /***/ }),
-/* 300 */
+/* 299 */
 /***/ (function(module, exports) {
 
 /**
@@ -31528,10 +31553,10 @@ module.exports = listCacheClear;
 
 
 /***/ }),
-/* 301 */
+/* 300 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assocIndexOf = __webpack_require__(21);
+var assocIndexOf = __webpack_require__(22);
 
 /** Used for built-in method references. */
 var arrayProto = Array.prototype;
@@ -31569,10 +31594,10 @@ module.exports = listCacheDelete;
 
 
 /***/ }),
-/* 302 */
+/* 301 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assocIndexOf = __webpack_require__(21);
+var assocIndexOf = __webpack_require__(22);
 
 /**
  * Gets the list cache value for `key`.
@@ -31594,10 +31619,10 @@ module.exports = listCacheGet;
 
 
 /***/ }),
-/* 303 */
+/* 302 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assocIndexOf = __webpack_require__(21);
+var assocIndexOf = __webpack_require__(22);
 
 /**
  * Checks if a list cache value for `key` exists.
@@ -31616,10 +31641,10 @@ module.exports = listCacheHas;
 
 
 /***/ }),
-/* 304 */
+/* 303 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var assocIndexOf = __webpack_require__(21);
+var assocIndexOf = __webpack_require__(22);
 
 /**
  * Sets the list cache `key` to `value`.
@@ -31648,12 +31673,12 @@ module.exports = listCacheSet;
 
 
 /***/ }),
-/* 305 */
+/* 304 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var Hash = __webpack_require__(251),
-    ListCache = __webpack_require__(19),
-    Map = __webpack_require__(63);
+var Hash = __webpack_require__(250),
+    ListCache = __webpack_require__(20),
+    Map = __webpack_require__(61);
 
 /**
  * Removes all key-value entries from the map.
@@ -31675,10 +31700,10 @@ module.exports = mapCacheClear;
 
 
 /***/ }),
-/* 306 */
+/* 305 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getMapData = __webpack_require__(23);
+var getMapData = __webpack_require__(24);
 
 /**
  * Removes `key` and its value from the map.
@@ -31699,10 +31724,10 @@ module.exports = mapCacheDelete;
 
 
 /***/ }),
-/* 307 */
+/* 306 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getMapData = __webpack_require__(23);
+var getMapData = __webpack_require__(24);
 
 /**
  * Gets the map value for `key`.
@@ -31721,10 +31746,10 @@ module.exports = mapCacheGet;
 
 
 /***/ }),
-/* 308 */
+/* 307 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getMapData = __webpack_require__(23);
+var getMapData = __webpack_require__(24);
 
 /**
  * Checks if a map value for `key` exists.
@@ -31743,10 +31768,10 @@ module.exports = mapCacheHas;
 
 
 /***/ }),
-/* 309 */
+/* 308 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var getMapData = __webpack_require__(23);
+var getMapData = __webpack_require__(24);
 
 /**
  * Sets the map `key` to `value`.
@@ -31771,10 +31796,10 @@ module.exports = mapCacheSet;
 
 
 /***/ }),
-/* 310 */
+/* 309 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var memoize = __webpack_require__(329);
+var memoize = __webpack_require__(328);
 
 /** Used as the maximum memoize cache size. */
 var MAX_MEMOIZE_SIZE = 500;
@@ -31803,7 +31828,7 @@ module.exports = memoizeCapped;
 
 
 /***/ }),
-/* 311 */
+/* 310 */
 /***/ (function(module, exports) {
 
 /**
@@ -31829,10 +31854,10 @@ module.exports = nativeKeysIn;
 
 
 /***/ }),
-/* 312 */
+/* 311 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(module) {var freeGlobal = __webpack_require__(69);
+/* WEBPACK VAR INJECTION */(function(module) {var freeGlobal = __webpack_require__(67);
 
 /** Detect free variable `exports`. */
 var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
@@ -31858,7 +31883,7 @@ module.exports = nodeUtil;
 /* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(30)(module)))
 
 /***/ }),
-/* 313 */
+/* 312 */
 /***/ (function(module, exports) {
 
 /** Used for built-in method references. */
@@ -31886,7 +31911,7 @@ module.exports = objectToString;
 
 
 /***/ }),
-/* 314 */
+/* 313 */
 /***/ (function(module, exports) {
 
 /**
@@ -31907,7 +31932,7 @@ module.exports = overArg;
 
 
 /***/ }),
-/* 315 */
+/* 314 */
 /***/ (function(module, exports) {
 
 /** Used to detect hot functions by number of calls within a span of milliseconds. */
@@ -31950,10 +31975,10 @@ module.exports = shortOut;
 
 
 /***/ }),
-/* 316 */
+/* 315 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var ListCache = __webpack_require__(19);
+var ListCache = __webpack_require__(20);
 
 /**
  * Removes all key-value entries from the stack.
@@ -31971,7 +31996,7 @@ module.exports = stackClear;
 
 
 /***/ }),
-/* 317 */
+/* 316 */
 /***/ (function(module, exports) {
 
 /**
@@ -31995,7 +32020,7 @@ module.exports = stackDelete;
 
 
 /***/ }),
-/* 318 */
+/* 317 */
 /***/ (function(module, exports) {
 
 /**
@@ -32015,7 +32040,7 @@ module.exports = stackGet;
 
 
 /***/ }),
-/* 319 */
+/* 318 */
 /***/ (function(module, exports) {
 
 /**
@@ -32035,12 +32060,12 @@ module.exports = stackHas;
 
 
 /***/ }),
-/* 320 */
+/* 319 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var ListCache = __webpack_require__(19),
-    Map = __webpack_require__(63),
-    MapCache = __webpack_require__(64);
+var ListCache = __webpack_require__(20),
+    Map = __webpack_require__(61),
+    MapCache = __webpack_require__(62);
 
 /** Used as the size to enable large array optimizations. */
 var LARGE_ARRAY_SIZE = 200;
@@ -32075,10 +32100,10 @@ module.exports = stackSet;
 
 
 /***/ }),
-/* 321 */
+/* 320 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var memoizeCapped = __webpack_require__(310);
+var memoizeCapped = __webpack_require__(309);
 
 /** Used to match property names within property paths. */
 var reLeadingDot = /^\./,
@@ -32109,7 +32134,7 @@ module.exports = stringToPath;
 
 
 /***/ }),
-/* 322 */
+/* 321 */
 /***/ (function(module, exports) {
 
 /** Used for built-in method references. */
@@ -32141,7 +32166,7 @@ module.exports = toSource;
 
 
 /***/ }),
-/* 323 */
+/* 322 */
 /***/ (function(module, exports) {
 
 /**
@@ -32173,10 +32198,10 @@ module.exports = constant;
 
 
 /***/ }),
-/* 324 */
+/* 323 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseFlatten = __webpack_require__(259);
+var baseFlatten = __webpack_require__(258);
 
 /**
  * Flattens `array` a single level deep.
@@ -32201,10 +32226,10 @@ module.exports = flatten;
 
 
 /***/ }),
-/* 325 */
+/* 324 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseGet = __webpack_require__(67);
+var baseGet = __webpack_require__(65);
 
 /**
  * Gets the value at `path` of `object`. If the resolved value is
@@ -32240,11 +32265,11 @@ module.exports = get;
 
 
 /***/ }),
-/* 326 */
+/* 325 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseHasIn = __webpack_require__(261),
-    hasPath = __webpack_require__(289);
+var baseHasIn = __webpack_require__(260),
+    hasPath = __webpack_require__(288);
 
 /**
  * Checks if `path` is a direct or inherited property of `object`.
@@ -32280,11 +32305,11 @@ module.exports = hasIn;
 
 
 /***/ }),
-/* 327 */
+/* 326 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isArrayLike = __webpack_require__(48),
-    isObjectLike = __webpack_require__(11);
+var isArrayLike = __webpack_require__(45),
+    isObjectLike = __webpack_require__(10);
 
 /**
  * This method is like `_.isArrayLike` except that it also checks if `value`
@@ -32319,12 +32344,12 @@ module.exports = isArrayLikeObject;
 
 
 /***/ }),
-/* 328 */
+/* 327 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var baseGetTag = __webpack_require__(13),
-    getPrototype = __webpack_require__(70),
-    isObjectLike = __webpack_require__(11);
+    getPrototype = __webpack_require__(68),
+    isObjectLike = __webpack_require__(10);
 
 /** `Object#toString` result references. */
 var objectTag = '[object Object]';
@@ -32387,10 +32412,10 @@ module.exports = isPlainObject;
 
 
 /***/ }),
-/* 329 */
+/* 328 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var MapCache = __webpack_require__(64);
+var MapCache = __webpack_require__(62);
 
 /** Error message constants. */
 var FUNC_ERROR_TEXT = 'Expected a function';
@@ -32466,11 +32491,11 @@ module.exports = memoize;
 
 
 /***/ }),
-/* 330 */
+/* 329 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseMerge = __webpack_require__(266),
-    createAssigner = __webpack_require__(283);
+var baseMerge = __webpack_require__(265),
+    createAssigner = __webpack_require__(282);
 
 /**
  * This method is like `_.assign` except that it recursively merges own and
@@ -32511,10 +32536,10 @@ module.exports = merge;
 
 
 /***/ }),
-/* 331 */
+/* 330 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var createRange = __webpack_require__(285);
+var createRange = __webpack_require__(284);
 
 /**
  * Creates an array of numbers (positive and/or negative) progressing from
@@ -32563,7 +32588,7 @@ module.exports = range;
 
 
 /***/ }),
-/* 332 */
+/* 331 */
 /***/ (function(module, exports) {
 
 /**
@@ -32587,10 +32612,10 @@ module.exports = stubFalse;
 
 
 /***/ }),
-/* 333 */
+/* 332 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var toNumber = __webpack_require__(334);
+var toNumber = __webpack_require__(333);
 
 /** Used as references for various `Number` constants. */
 var INFINITY = 1 / 0,
@@ -32635,11 +32660,11 @@ module.exports = toFinite;
 
 
 /***/ }),
-/* 334 */
+/* 333 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var isObject = __webpack_require__(4),
-    isSymbol = __webpack_require__(28);
+var isObject = __webpack_require__(5),
+    isSymbol = __webpack_require__(29);
 
 /** Used as references for various `Number` constants. */
 var NAN = 0 / 0;
@@ -32707,11 +32732,11 @@ module.exports = toNumber;
 
 
 /***/ }),
-/* 335 */
+/* 334 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var copyObject = __webpack_require__(281),
-    keysIn = __webpack_require__(78);
+var copyObject = __webpack_require__(280),
+    keysIn = __webpack_require__(76);
 
 /**
  * Converts `value` to a plain object flattening inherited enumerable string
@@ -32745,10 +32770,10 @@ module.exports = toPlainObject;
 
 
 /***/ }),
-/* 336 */
+/* 335 */
 /***/ (function(module, exports, __webpack_require__) {
 
-var baseToString = __webpack_require__(275);
+var baseToString = __webpack_require__(274);
 
 /**
  * Converts `value` to a string. An empty string is returned for `null`
@@ -32779,240 +32804,240 @@ module.exports = toString;
 
 
 /***/ }),
-/* 337 */
+/* 336 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var map = {
-	"./af": 80,
-	"./af.js": 80,
-	"./ar": 87,
-	"./ar-dz": 81,
-	"./ar-dz.js": 81,
-	"./ar-kw": 82,
-	"./ar-kw.js": 82,
-	"./ar-ly": 83,
-	"./ar-ly.js": 83,
-	"./ar-ma": 84,
-	"./ar-ma.js": 84,
-	"./ar-sa": 85,
-	"./ar-sa.js": 85,
-	"./ar-tn": 86,
-	"./ar-tn.js": 86,
-	"./ar.js": 87,
-	"./az": 88,
-	"./az.js": 88,
-	"./be": 89,
-	"./be.js": 89,
-	"./bg": 90,
-	"./bg.js": 90,
-	"./bn": 91,
-	"./bn.js": 91,
-	"./bo": 92,
-	"./bo.js": 92,
-	"./br": 93,
-	"./br.js": 93,
-	"./bs": 94,
-	"./bs.js": 94,
-	"./ca": 95,
-	"./ca.js": 95,
-	"./cs": 96,
-	"./cs.js": 96,
-	"./cv": 97,
-	"./cv.js": 97,
-	"./cy": 98,
-	"./cy.js": 98,
-	"./da": 99,
-	"./da.js": 99,
-	"./de": 102,
-	"./de-at": 100,
-	"./de-at.js": 100,
-	"./de-ch": 101,
-	"./de-ch.js": 101,
-	"./de.js": 102,
-	"./dv": 103,
-	"./dv.js": 103,
-	"./el": 104,
-	"./el.js": 104,
-	"./en-au": 105,
-	"./en-au.js": 105,
-	"./en-ca": 106,
-	"./en-ca.js": 106,
-	"./en-gb": 107,
-	"./en-gb.js": 107,
-	"./en-ie": 108,
-	"./en-ie.js": 108,
-	"./en-nz": 109,
-	"./en-nz.js": 109,
-	"./eo": 110,
-	"./eo.js": 110,
-	"./es": 112,
-	"./es-do": 111,
-	"./es-do.js": 111,
-	"./es.js": 112,
-	"./et": 113,
-	"./et.js": 113,
-	"./eu": 114,
-	"./eu.js": 114,
-	"./fa": 115,
-	"./fa.js": 115,
-	"./fi": 116,
-	"./fi.js": 116,
-	"./fo": 117,
-	"./fo.js": 117,
-	"./fr": 120,
-	"./fr-ca": 118,
-	"./fr-ca.js": 118,
-	"./fr-ch": 119,
-	"./fr-ch.js": 119,
-	"./fr.js": 120,
-	"./fy": 121,
-	"./fy.js": 121,
-	"./gd": 122,
-	"./gd.js": 122,
-	"./gl": 123,
-	"./gl.js": 123,
-	"./gom-latn": 124,
-	"./gom-latn.js": 124,
-	"./he": 125,
-	"./he.js": 125,
-	"./hi": 126,
-	"./hi.js": 126,
-	"./hr": 127,
-	"./hr.js": 127,
-	"./hu": 128,
-	"./hu.js": 128,
-	"./hy-am": 129,
-	"./hy-am.js": 129,
-	"./id": 130,
-	"./id.js": 130,
-	"./is": 131,
-	"./is.js": 131,
-	"./it": 132,
-	"./it.js": 132,
-	"./ja": 133,
-	"./ja.js": 133,
-	"./jv": 134,
-	"./jv.js": 134,
-	"./ka": 135,
-	"./ka.js": 135,
-	"./kk": 136,
-	"./kk.js": 136,
-	"./km": 137,
-	"./km.js": 137,
-	"./kn": 138,
-	"./kn.js": 138,
-	"./ko": 139,
-	"./ko.js": 139,
-	"./ky": 140,
-	"./ky.js": 140,
-	"./lb": 141,
-	"./lb.js": 141,
-	"./lo": 142,
-	"./lo.js": 142,
-	"./lt": 143,
-	"./lt.js": 143,
-	"./lv": 144,
-	"./lv.js": 144,
-	"./me": 145,
-	"./me.js": 145,
-	"./mi": 146,
-	"./mi.js": 146,
-	"./mk": 147,
-	"./mk.js": 147,
-	"./ml": 148,
-	"./ml.js": 148,
-	"./mr": 149,
-	"./mr.js": 149,
-	"./ms": 151,
-	"./ms-my": 150,
-	"./ms-my.js": 150,
-	"./ms.js": 151,
-	"./my": 152,
-	"./my.js": 152,
-	"./nb": 153,
-	"./nb.js": 153,
-	"./ne": 154,
-	"./ne.js": 154,
-	"./nl": 156,
-	"./nl-be": 155,
-	"./nl-be.js": 155,
-	"./nl.js": 156,
-	"./nn": 157,
-	"./nn.js": 157,
-	"./pa-in": 158,
-	"./pa-in.js": 158,
-	"./pl": 159,
-	"./pl.js": 159,
-	"./pt": 161,
-	"./pt-br": 160,
-	"./pt-br.js": 160,
-	"./pt.js": 161,
-	"./ro": 162,
-	"./ro.js": 162,
-	"./ru": 163,
-	"./ru.js": 163,
-	"./sd": 164,
-	"./sd.js": 164,
-	"./se": 165,
-	"./se.js": 165,
-	"./si": 166,
-	"./si.js": 166,
-	"./sk": 167,
-	"./sk.js": 167,
-	"./sl": 168,
-	"./sl.js": 168,
-	"./sq": 169,
-	"./sq.js": 169,
-	"./sr": 171,
-	"./sr-cyrl": 170,
-	"./sr-cyrl.js": 170,
-	"./sr.js": 171,
-	"./ss": 172,
-	"./ss.js": 172,
-	"./sv": 173,
-	"./sv.js": 173,
-	"./sw": 174,
-	"./sw.js": 174,
-	"./ta": 175,
-	"./ta.js": 175,
-	"./te": 176,
-	"./te.js": 176,
-	"./tet": 177,
-	"./tet.js": 177,
-	"./th": 178,
-	"./th.js": 178,
-	"./tl-ph": 179,
-	"./tl-ph.js": 179,
-	"./tlh": 180,
-	"./tlh.js": 180,
-	"./tr": 181,
-	"./tr.js": 181,
-	"./tzl": 182,
-	"./tzl.js": 182,
-	"./tzm": 184,
-	"./tzm-latn": 183,
-	"./tzm-latn.js": 183,
-	"./tzm.js": 184,
-	"./uk": 185,
-	"./uk.js": 185,
-	"./ur": 186,
-	"./ur.js": 186,
-	"./uz": 188,
-	"./uz-latn": 187,
-	"./uz-latn.js": 187,
-	"./uz.js": 188,
-	"./vi": 189,
-	"./vi.js": 189,
-	"./x-pseudo": 190,
-	"./x-pseudo.js": 190,
-	"./yo": 191,
-	"./yo.js": 191,
-	"./zh-cn": 192,
-	"./zh-cn.js": 192,
-	"./zh-hk": 193,
-	"./zh-hk.js": 193,
-	"./zh-tw": 194,
-	"./zh-tw.js": 194
+	"./af": 78,
+	"./af.js": 78,
+	"./ar": 85,
+	"./ar-dz": 79,
+	"./ar-dz.js": 79,
+	"./ar-kw": 80,
+	"./ar-kw.js": 80,
+	"./ar-ly": 81,
+	"./ar-ly.js": 81,
+	"./ar-ma": 82,
+	"./ar-ma.js": 82,
+	"./ar-sa": 83,
+	"./ar-sa.js": 83,
+	"./ar-tn": 84,
+	"./ar-tn.js": 84,
+	"./ar.js": 85,
+	"./az": 86,
+	"./az.js": 86,
+	"./be": 87,
+	"./be.js": 87,
+	"./bg": 88,
+	"./bg.js": 88,
+	"./bn": 89,
+	"./bn.js": 89,
+	"./bo": 90,
+	"./bo.js": 90,
+	"./br": 91,
+	"./br.js": 91,
+	"./bs": 92,
+	"./bs.js": 92,
+	"./ca": 93,
+	"./ca.js": 93,
+	"./cs": 94,
+	"./cs.js": 94,
+	"./cv": 95,
+	"./cv.js": 95,
+	"./cy": 96,
+	"./cy.js": 96,
+	"./da": 97,
+	"./da.js": 97,
+	"./de": 100,
+	"./de-at": 98,
+	"./de-at.js": 98,
+	"./de-ch": 99,
+	"./de-ch.js": 99,
+	"./de.js": 100,
+	"./dv": 101,
+	"./dv.js": 101,
+	"./el": 102,
+	"./el.js": 102,
+	"./en-au": 103,
+	"./en-au.js": 103,
+	"./en-ca": 104,
+	"./en-ca.js": 104,
+	"./en-gb": 105,
+	"./en-gb.js": 105,
+	"./en-ie": 106,
+	"./en-ie.js": 106,
+	"./en-nz": 107,
+	"./en-nz.js": 107,
+	"./eo": 108,
+	"./eo.js": 108,
+	"./es": 110,
+	"./es-do": 109,
+	"./es-do.js": 109,
+	"./es.js": 110,
+	"./et": 111,
+	"./et.js": 111,
+	"./eu": 112,
+	"./eu.js": 112,
+	"./fa": 113,
+	"./fa.js": 113,
+	"./fi": 114,
+	"./fi.js": 114,
+	"./fo": 115,
+	"./fo.js": 115,
+	"./fr": 118,
+	"./fr-ca": 116,
+	"./fr-ca.js": 116,
+	"./fr-ch": 117,
+	"./fr-ch.js": 117,
+	"./fr.js": 118,
+	"./fy": 119,
+	"./fy.js": 119,
+	"./gd": 120,
+	"./gd.js": 120,
+	"./gl": 121,
+	"./gl.js": 121,
+	"./gom-latn": 122,
+	"./gom-latn.js": 122,
+	"./he": 123,
+	"./he.js": 123,
+	"./hi": 124,
+	"./hi.js": 124,
+	"./hr": 125,
+	"./hr.js": 125,
+	"./hu": 126,
+	"./hu.js": 126,
+	"./hy-am": 127,
+	"./hy-am.js": 127,
+	"./id": 128,
+	"./id.js": 128,
+	"./is": 129,
+	"./is.js": 129,
+	"./it": 130,
+	"./it.js": 130,
+	"./ja": 131,
+	"./ja.js": 131,
+	"./jv": 132,
+	"./jv.js": 132,
+	"./ka": 133,
+	"./ka.js": 133,
+	"./kk": 134,
+	"./kk.js": 134,
+	"./km": 135,
+	"./km.js": 135,
+	"./kn": 136,
+	"./kn.js": 136,
+	"./ko": 137,
+	"./ko.js": 137,
+	"./ky": 138,
+	"./ky.js": 138,
+	"./lb": 139,
+	"./lb.js": 139,
+	"./lo": 140,
+	"./lo.js": 140,
+	"./lt": 141,
+	"./lt.js": 141,
+	"./lv": 142,
+	"./lv.js": 142,
+	"./me": 143,
+	"./me.js": 143,
+	"./mi": 144,
+	"./mi.js": 144,
+	"./mk": 145,
+	"./mk.js": 145,
+	"./ml": 146,
+	"./ml.js": 146,
+	"./mr": 147,
+	"./mr.js": 147,
+	"./ms": 149,
+	"./ms-my": 148,
+	"./ms-my.js": 148,
+	"./ms.js": 149,
+	"./my": 150,
+	"./my.js": 150,
+	"./nb": 151,
+	"./nb.js": 151,
+	"./ne": 152,
+	"./ne.js": 152,
+	"./nl": 154,
+	"./nl-be": 153,
+	"./nl-be.js": 153,
+	"./nl.js": 154,
+	"./nn": 155,
+	"./nn.js": 155,
+	"./pa-in": 156,
+	"./pa-in.js": 156,
+	"./pl": 157,
+	"./pl.js": 157,
+	"./pt": 159,
+	"./pt-br": 158,
+	"./pt-br.js": 158,
+	"./pt.js": 159,
+	"./ro": 160,
+	"./ro.js": 160,
+	"./ru": 161,
+	"./ru.js": 161,
+	"./sd": 162,
+	"./sd.js": 162,
+	"./se": 163,
+	"./se.js": 163,
+	"./si": 164,
+	"./si.js": 164,
+	"./sk": 165,
+	"./sk.js": 165,
+	"./sl": 166,
+	"./sl.js": 166,
+	"./sq": 167,
+	"./sq.js": 167,
+	"./sr": 169,
+	"./sr-cyrl": 168,
+	"./sr-cyrl.js": 168,
+	"./sr.js": 169,
+	"./ss": 170,
+	"./ss.js": 170,
+	"./sv": 171,
+	"./sv.js": 171,
+	"./sw": 172,
+	"./sw.js": 172,
+	"./ta": 173,
+	"./ta.js": 173,
+	"./te": 174,
+	"./te.js": 174,
+	"./tet": 175,
+	"./tet.js": 175,
+	"./th": 176,
+	"./th.js": 176,
+	"./tl-ph": 177,
+	"./tl-ph.js": 177,
+	"./tlh": 178,
+	"./tlh.js": 178,
+	"./tr": 179,
+	"./tr.js": 179,
+	"./tzl": 180,
+	"./tzl.js": 180,
+	"./tzm": 182,
+	"./tzm-latn": 181,
+	"./tzm-latn.js": 181,
+	"./tzm.js": 182,
+	"./uk": 183,
+	"./uk.js": 183,
+	"./ur": 184,
+	"./ur.js": 184,
+	"./uz": 186,
+	"./uz-latn": 185,
+	"./uz-latn.js": 185,
+	"./uz.js": 186,
+	"./vi": 187,
+	"./vi.js": 187,
+	"./x-pseudo": 188,
+	"./x-pseudo.js": 188,
+	"./yo": 189,
+	"./yo.js": 189,
+	"./zh-cn": 190,
+	"./zh-cn.js": 190,
+	"./zh-hk": 191,
+	"./zh-hk.js": 191,
+	"./zh-tw": 192,
+	"./zh-tw.js": 192
 };
 function webpackContext(req) {
 	return __webpack_require__(webpackContextResolve(req));
@@ -33028,18 +33053,15 @@ webpackContext.keys = function webpackContextKeys() {
 };
 webpackContext.resolve = webpackContextResolve;
 module.exports = webpackContext;
-webpackContext.id = 337;
+webpackContext.id = 336;
 
 /***/ }),
-/* 338 */
+/* 337 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(global) {// This method of obtaining a reference to the global object needs to be
+// This method of obtaining a reference to the global object needs to be
 // kept identical to the way it is obtained in runtime.js
-var g =
-  typeof global === "object" ? global :
-  typeof window === "object" ? window :
-  typeof self === "object" ? self : this;
+var g = (function() { return this })() || Function("return this")();
 
 // Use `getOwnPropertyNames` because not all browsers support calling
 // `hasOwnProperty` on the global `self` object in a worker. See #183.
@@ -33052,7 +33074,7 @@ var oldRuntime = hadRuntime && g.regeneratorRuntime;
 // Force reevalutation of runtime.js.
 g.regeneratorRuntime = undefined;
 
-module.exports = __webpack_require__(339);
+module.exports = __webpack_require__(338);
 
 if (hadRuntime) {
   // Restore the original runtime.
@@ -33066,13 +33088,12 @@ if (hadRuntime) {
   }
 }
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(29)))
 
 /***/ }),
-/* 339 */
-/***/ (function(module, exports, __webpack_require__) {
+/* 338 */
+/***/ (function(module, exports) {
 
-/* WEBPACK VAR INJECTION */(function(global) {/**
+/**
  * Copyright (c) 2014, Facebook, Inc.
  * All rights reserved.
  *
@@ -33262,10 +33283,6 @@ if (hadRuntime) {
           resolve(result);
         }, reject);
       }
-    }
-
-    if (typeof global.process === "object" && global.process.domain) {
-      invoke = global.process.domain.bind(invoke);
     }
 
     var previousPromise;
@@ -33801,241 +33818,51 @@ if (hadRuntime) {
     }
   };
 })(
-  // Among the various tricks for obtaining a reference to the global
-  // object, this seems to be the most reliable technique that does not
-  // use indirect eval (which violates Content Security Policy).
-  typeof global === "object" ? global :
-  typeof window === "object" ? window :
-  typeof self === "object" ? self : this
+  // In sloppy mode, unbound `this` refers to the global object, fallback to
+  // Function constructor if we're in global strict mode. That is sadly a form
+  // of indirect eval which violates Content Security Policy.
+  (function() { return this })() || Function("return this")()
 );
 
-/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(29)))
+
+/***/ }),
+/* 339 */
+/***/ (function(module, exports, __webpack_require__) {
+
+var Component = __webpack_require__(14)(
+  /* script */
+  __webpack_require__(199),
+  /* template */
+  __webpack_require__(343),
+  /* styles */
+  null,
+  /* scopeId */
+  null,
+  /* moduleIdentifier (server only) */
+  null
+)
+
+module.exports = Component.exports
+
 
 /***/ }),
 /* 340 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-var __WEBPACK_AMD_DEFINE_RESULT__;
+var Component = __webpack_require__(14)(
+  /* script */
+  __webpack_require__(200),
+  /* template */
+  __webpack_require__(347),
+  /* styles */
+  null,
+  /* scopeId */
+  null,
+  /* moduleIdentifier (server only) */
+  null
+)
 
-(function (global) {
-
-    const STATE_PLAINTEXT = Symbol('plaintext');
-    const STATE_HTML      = Symbol('html');
-    const STATE_COMMENT   = Symbol('comment');
-
-    const ALLOWED_TAGS_REGEX  = /<(\w*)>/g;
-    const NORMALIZE_TAG_REGEX = /<\/?([^\s\/>]+)/;
-
-    function striptags(html, allowable_tags, tag_replacement) {
-        html            = html || '';
-        allowable_tags  = allowable_tags || [];
-        tag_replacement = tag_replacement || '';
-
-        let context = init_context(allowable_tags, tag_replacement);
-
-        return striptags_internal(html, context);
-    }
-
-    function init_striptags_stream(allowable_tags, tag_replacement) {
-        allowable_tags  = allowable_tags || [];
-        tag_replacement = tag_replacement || '';
-
-        let context = init_context(allowable_tags, tag_replacement);
-
-        return function striptags_stream(html) {
-            return striptags_internal(html || '', context);
-        };
-    }
-
-    striptags.init_streaming_mode = init_striptags_stream;
-
-    function init_context(allowable_tags, tag_replacement) {
-        allowable_tags = parse_allowable_tags(allowable_tags);
-
-        return {
-            allowable_tags,
-            tag_replacement,
-
-            state         : STATE_PLAINTEXT,
-            tag_buffer    : '',
-            depth         : 0,
-            in_quote_char : ''
-        };
-    }
-
-    function striptags_internal(html, context) {
-        let allowable_tags  = context.allowable_tags;
-        let tag_replacement = context.tag_replacement;
-
-        let state         = context.state;
-        let tag_buffer    = context.tag_buffer;
-        let depth         = context.depth;
-        let in_quote_char = context.in_quote_char;
-        let output        = '';
-
-        for (let idx = 0, length = html.length; idx < length; idx++) {
-            let char = html[idx];
-
-            if (state === STATE_PLAINTEXT) {
-                switch (char) {
-                    case '<':
-                        state       = STATE_HTML;
-                        tag_buffer += char;
-                        break;
-
-                    default:
-                        output += char;
-                        break;
-                }
-            }
-
-            else if (state === STATE_HTML) {
-                switch (char) {
-                    case '<':
-                        // ignore '<' if inside a quote
-                        if (in_quote_char) {
-                            break;
-                        }
-
-                        // we're seeing a nested '<'
-                        depth++;
-                        break;
-
-                    case '>':
-                        // ignore '>' if inside a quote
-                        if (in_quote_char) {
-                            break;
-                        }
-
-                        // something like this is happening: '<<>>'
-                        if (depth) {
-                            depth--;
-
-                            break;
-                        }
-
-                        // this is closing the tag in tag_buffer
-                        in_quote_char = '';
-                        state         = STATE_PLAINTEXT;
-                        tag_buffer   += '>';
-
-                        if (allowable_tags.has(normalize_tag(tag_buffer))) {
-                            output += tag_buffer;
-                        } else {
-                            output += tag_replacement;
-                        }
-
-                        tag_buffer = '';
-                        break;
-
-                    case '"':
-                    case '\'':
-                        // catch both single and double quotes
-
-                        if (char === in_quote_char) {
-                            in_quote_char = '';
-                        } else {
-                            in_quote_char = in_quote_char || char;
-                        }
-
-                        tag_buffer += char;
-                        break;
-
-                    case '-':
-                        if (tag_buffer === '<!-') {
-                            state = STATE_COMMENT;
-                        }
-
-                        tag_buffer += char;
-                        break;
-
-                    case ' ':
-                    case '\n':
-                        if (tag_buffer === '<') {
-                            state      = STATE_PLAINTEXT;
-                            output    += '< ';
-                            tag_buffer = '';
-
-                            break;
-                        }
-
-                        tag_buffer += char;
-                        break;
-
-                    default:
-                        tag_buffer += char;
-                        break;
-                }
-            }
-
-            else if (state === STATE_COMMENT) {
-                switch (char) {
-                    case '>':
-                        if (tag_buffer.slice(-2) == '--') {
-                            // close the comment
-                            state = STATE_PLAINTEXT;
-                        }
-
-                        tag_buffer = '';
-                        break;
-
-                    default:
-                        tag_buffer += char;
-                        break;
-                }
-            }
-        }
-
-        // save the context for future iterations
-        context.state         = state;
-        context.tag_buffer    = tag_buffer;
-        context.depth         = depth;
-        context.in_quote_char = in_quote_char;
-
-        return output;
-    }
-
-    function parse_allowable_tags(allowable_tags) {
-        let tags_array = [];
-
-        if (typeof allowable_tags === 'string') {
-            let match;
-
-            while ((match = ALLOWED_TAGS_REGEX.exec(allowable_tags)) !== null) {
-                tags_array.push(match[1]);
-            }
-        }
-
-        else if (typeof allowable_tags[Symbol.iterator] === 'function') {
-            tags_array = allowable_tags;
-        }
-
-        return new Set(tags_array);
-    }
-
-    function normalize_tag(tag_buffer) {
-        let match = NORMALIZE_TAG_REGEX.exec(tag_buffer);
-
-        return match ? match[1].toLowerCase() : null;
-    }
-
-    if (true) {
-        // AMD
-        !(__WEBPACK_AMD_DEFINE_RESULT__ = function module_factory() { return striptags; }.call(exports, __webpack_require__, exports, module),
-				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
-    }
-
-    else if (typeof module === 'object' && module.exports) {
-        // Node
-        module.exports = striptags;
-    }
-
-    else {
-        // Browser
-        global.striptags = striptags;
-    }
-}(this));
+module.exports = Component.exports
 
 
 /***/ }),
@@ -34044,9 +33871,9 @@ var __WEBPACK_AMD_DEFINE_RESULT__;
 
 var Component = __webpack_require__(14)(
   /* script */
-  __webpack_require__(200),
+  __webpack_require__(201),
   /* template */
-  __webpack_require__(345),
+  __webpack_require__(346),
   /* styles */
   null,
   /* scopeId */
@@ -34064,9 +33891,9 @@ module.exports = Component.exports
 
 var Component = __webpack_require__(14)(
   /* script */
-  __webpack_require__(201),
+  __webpack_require__(202),
   /* template */
-  __webpack_require__(349),
+  __webpack_require__(344),
   /* styles */
   null,
   /* scopeId */
@@ -34080,46 +33907,6 @@ module.exports = Component.exports
 
 /***/ }),
 /* 343 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var Component = __webpack_require__(14)(
-  /* script */
-  __webpack_require__(202),
-  /* template */
-  __webpack_require__(348),
-  /* styles */
-  null,
-  /* scopeId */
-  null,
-  /* moduleIdentifier (server only) */
-  null
-)
-
-module.exports = Component.exports
-
-
-/***/ }),
-/* 344 */
-/***/ (function(module, exports, __webpack_require__) {
-
-var Component = __webpack_require__(14)(
-  /* script */
-  __webpack_require__(203),
-  /* template */
-  __webpack_require__(346),
-  /* styles */
-  null,
-  /* scopeId */
-  null,
-  /* moduleIdentifier (server only) */
-  null
-)
-
-module.exports = Component.exports
-
-
-/***/ }),
-/* 345 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -34127,7 +33914,7 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
 },staticRenderFns: []}
 
 /***/ }),
-/* 346 */
+/* 344 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -34142,7 +33929,7 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
 },staticRenderFns: []}
 
 /***/ }),
-/* 347 */
+/* 345 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
@@ -34166,13 +33953,13 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
 },staticRenderFns: []}
 
 /***/ }),
-/* 348 */
+/* 346 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;
   return _c('div', {
     staticClass: "table-component"
-  }, [(_vm.showFilter) ? _c('div', {
+  }, [(_vm.showFilter && _vm.filterableColumnExists) ? _c('div', {
     staticClass: "table-component__filter"
   }, [_c('input', {
     directives: [{
@@ -34212,7 +33999,9 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
       "role": "alert",
       "aria-live": "polite"
     }
-  }, [_vm._v("\n                " + _vm._s(_vm.ariaCaption) + "\n            ")]) : _vm._e(), _vm._v(" "), _c('thead', [_c('tr', _vm._l((_vm.columns), function(column) {
+  }, [_vm._v("\n                " + _vm._s(_vm.ariaCaption) + "\n            ")]) : _vm._e(), _vm._v(" "), _c('thead', {
+    class: _vm.fullTableHeadClass
+  }, [_c('tr', _vm._l((_vm.columns), function(column) {
     return _c('table-column-header', {
       key: column.show,
       attrs: {
@@ -34223,7 +34012,9 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
         "click": _vm.changeSorting
       }
     })
-  }))]), _vm._v(" "), _c('tbody', _vm._l((_vm.displayedRows), function(row) {
+  }))]), _vm._v(" "), _c('tbody', {
+    class: _vm.fullTableBodyClass
+  }, _vm._l((_vm.displayedRows), function(row) {
     return _c('table-row', {
       key: row.vueTableComponentInternalRowId,
       attrs: {
@@ -34231,7 +34022,9 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
         "columns": _vm.columns
       }
     })
-  }))])]), _vm._v(" "), (_vm.displayedRows.length === 0) ? _c('div', {
+  })), _vm._v(" "), _c('tfoot', [_vm._t("tfoot", null, {
+    rows: _vm.rows
+  })], 2)])]), _vm._v(" "), (_vm.displayedRows.length === 0) ? _c('div', {
     staticClass: "table-component__message"
   }, [_vm._v("\n        " + _vm._s(_vm.filterNoResults) + "\n    ")]) : _vm._e(), _vm._v(" "), _c('div', {
     staticStyle: {
@@ -34248,7 +34041,7 @@ module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c
 },staticRenderFns: []}
 
 /***/ }),
-/* 349 */
+/* 347 */
 /***/ (function(module, exports) {
 
 module.exports={render:function (){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;

--- a/docs/index.html
+++ b/docs/index.html
@@ -153,13 +153,13 @@
                     </a>
                 </template>
             </table-column>
-            <template slot="tfoot">
+            <template slot="tfoot" scope="{ rows }">
                 <tr>
                     <th>&nbsp;</th>
                     <th>&nbsp;</th>
+                    <th>Total Songs:</th>
+                    <th>{{ rows.reduce((sum, value) => { return sum + value.data.songs; }, 0) }}</th>
                     <th>&nbsp;</th>
-                    <th>Total:</th>
-                    <th>166</th>
                     <th>&nbsp;</th>
                 </tr>
             </template>

--- a/docs/index.html
+++ b/docs/index.html
@@ -153,6 +153,16 @@
                     </a>
                 </template>
             </table-column>
+            <template slot="tfoot">
+                <tr>
+                    <th>&nbsp;</th>
+                    <th>&nbsp;</th>
+                    <th>&nbsp;</th>
+                    <th>Total:</th>
+                    <th>166</th>
+                    <th>&nbsp;</th>
+                </tr>
+            </template>
         </table-component>
 
     <section class="page-about">

--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -39,7 +39,7 @@
                 ></table-row>
                 </tbody>
                 <tfoot>
-                    <slot name="tfoot"></slot>
+                    <slot name="tfoot" :rows="rows"></slot>
                 </tfoot>
             </table>
         </div>

--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -38,6 +38,9 @@
                         :columns="columns"
                 ></table-row>
                 </tbody>
+                <tfoot>
+                    <slot name="tfoot"></slot>
+                </tfoot>
             </table>
         </div>
 
@@ -74,7 +77,7 @@
         },
 
         props: {
-            data: {default: () => [], type: [Array, Function]},
+            data: { default: () => [], type: [Array, Function] },
 
             showFilter: { default: true },
             showCaption: { default: true },


### PR DESCRIPTION
While I understand your project has no use case for a summary row, I wanted to propose a very lightweight option to show `tfoot` data within a named slot.  When not using the slot, it will add harmless `<tfoot></tfoot>` markup as I thought a hide/show option was unnecessary.

Commit message:
Add test for `tfoot` slot
Minor lint cleanup