### PR TITLE
fix #88 - component lists rendered with v-for should have explicit keys

### DIFF
--- a/src/components/TableRow.vue
+++ b/src/components/TableRow.vue
@@ -4,6 +4,7 @@
             v-for="column in visibleColumns"
             :row="row"
             :column="column"
+            :key="column.id"
         ></table-cell>
     </tr>
 </template>


### PR DESCRIPTION
This is a simple fix for the webpack warning in issue #88 
I know it's not ideal to track columns with the column itself, I think a better way would be to have an internalColumnId as you do for rows with vueTableComponentInternalRowId.

 