### PR TITLE
Expose the row item index to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,33 @@ export default {
 
 This will display values `Hi, I am John` and `Hi, I am Paul`.
 
+## Using the row index number
+
+```html
+<table-component
+     :data="[
+          { firstName: 'John', lastName: 'Lennon' },
+          { firstName: 'Paul', lastName: 'McCartney'},
+          { firstName: 'George', lastName: 'Harrison'},
+          { firstName: 'Ringo', lastName: 'Starr'},
+     ]"
+     sort-by="songs"
+     sort-order="asc"
+>
+     <table-column show="index" label="#"></table-column>
+     <table-column show="firstName" label="First name"></table-column>
+     <table-column show="lastName" label="Last name"></table-column>
+     <table-column label="#" :sortable="false" :filterable="false">
+         <template scope="row">
+            {{ row.index }}
+         </template>
+     </table-column>
+ </table-component>
+```
+
+This is an example how to create a column which shows the index number of the row. The `show` prop must be set to `index`, while the `label` prop can be anything. The `index` is an internal variable holding the rows index number, which will recalculated on sorting and filtering. Sorting and filtering is disabled for this special row.
+Beside this, you can also access the `index` of the row in a template as shown in the example as well. It does not make sense to filter or sort on the index, therefore it is disabled, but you are free to turn it on.
+
 ## Adding table footer `<tfoot>` information
 
 Sometimes it can be useful to add information to the bottom of the table like summary data.

--- a/src/classes/Column.js
+++ b/src/classes/Column.js
@@ -16,7 +16,7 @@ export default class Column {
 
 
     isFilterable() {
-        return this.filterable;
+        return this.filterable && this.show !== 'index';
     }
 
     getFilterFieldName() {
@@ -24,7 +24,7 @@ export default class Column {
     }
 
     isSortable() {
-        return this.sortable;
+        return this.sortable && this.show !== 'index';
     }
 
     getSortPredicate(sortOrder, allColumns) {

--- a/src/components/TableCell.js
+++ b/src/components/TableCell.js
@@ -1,10 +1,12 @@
 export default {
     functional: true,
 
-    props: ['column', 'row'],
+    props: ['column', 'row', 'index'],
 
     render(createElement, { props }) {
         const data = {};
+
+        props.row.data['index'] = (props.index + 1);
 
         if (props.column.cellClass) {
             data.class = props.column.cellClass;

--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -32,9 +32,10 @@
                 </thead>
                 <tbody :class="fullTableBodyClass">
                 <table-row
-                        v-for="row in displayedRows"
+                        v-for="(row, index) in displayedRows"
                         :key="row.vueTableComponentInternalRowId"
                         :row="row"
+                        :index="index"
                         :columns="columns"
 						@rowClick="emitRowClick"
                 ></table-row>

--- a/src/components/TableRow.vue
+++ b/src/components/TableRow.vue
@@ -3,6 +3,7 @@
         <table-cell
             v-for="column in visibleColumns"
             :row="row"
+            :index="index"
             :column="column"
             :key="column.id"
         ></table-cell>
@@ -13,7 +14,7 @@
     import TableCell from './TableCell';
 
     export default {
-        props: ['columns', 'row'],
+        props: ['columns', 'row', 'index'],
 
         components: {
             TableCell,


### PR DESCRIPTION
This change accomplish two things:
- the user is able to access the row item index from within a template
- with `<table-column show="index" label="#"></table-column>`, the user is able to create just a row with the index

Fixes #72 