### PR TITLE
Allow getting object nested properties with dot

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,7 +13,7 @@ export function get(object, path) {
         return object;
     }
 
-    const [pathHead, pathTail] = path.split('.', 2);;
+    const [pathHead, pathTail] = path.split(/\.(.+)/);
 
     return get(object[pathHead], pathTail);
 }


### PR DESCRIPTION
Right now the get helper allow to get only first level nested properties
(with a.b.c it returns a.b)

With this PR it allows to get nested properties at any level