### PR TITLE
Fix incorrect prop name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can pass these props to `table-component`:
 - `sort-by`: the property in data on which to initially sort.
 - `sort-order`: the initial sort order.
 - `cache-lifetime`: the lifetime in minutes the component will cache the filter and sorting.
-- `cache-id`: if you use multiple instances of `table-component` on the same page you must set this to a unique value per instance.
+- `cache-key`: if you use multiple instances of `table-component` on the same page you must set this to a unique value per instance.
 - `table-class`: the passed value will be added to the `class` attribute of the rendered table
 - `thead-class`: the passed value will be added to the `class` attribute of the rendered table head.
 - `tbody-class`: the passed value will be added to the `class` attribute of the rendered table body.


### PR DESCRIPTION
The README docs still refers to a deprecated naming of the cache key property.