### PR TITLE
Add notes to provide settings on plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ TableComponent.settings({
 });
 ```
 
+You can also provide the custom settings on Vue plugin install hook:
+
+```js
+import Vue from 'vue';
+import TableComponent from 'vue-table-component';
+
+Vue.use(TableComponent, {
+    tableClass: '',
+    theadClass: '',
+    tbodyClass: '',
+    filterPlaceholder: 'Filter table…',
+    filterNoResults: 'There are no matching rows',
+});
+```
+
 ## Retrieving data asynchronously
 
 The component can fetch data in an asynchronous manner. The most common use case for this is fetching data from a server.


### PR DESCRIPTION
You can provide custom settings to the plugin on install.

I was in doubt about placing the note on the "Modifying the used texts and CSS classes" section or in "Instalation" section.

As suggested in #121 