### PR TITLE
Revert settings after each test

### DIFF
--- a/tests/components/TableComponent.test.js
+++ b/tests/components/TableComponent.test.js
@@ -7,6 +7,12 @@ describe('TableComponent', () => {
         localStorage.clear();
     });
 
+    afterEach(() => {
+        TableComponent.settings({
+            filterNoResults: 'There are no matching rows',
+        });
+    });
+
     it('can mount', async () => {
         document.body.innerHTML = `
             <div id="app">
@@ -192,11 +198,6 @@ describe('TableComponent', () => {
         `;
 
         await createVm();
-
-        // Revert for next tests (needs refactoring...)
-        TableComponent.settings({
-            filterNoResults: 'There are no matching rows',
-        });
 
         expect(document.body.innerHTML).toMatchSnapshot();
     });


### PR DESCRIPTION
It was being used in one test. If this code needs to be used in more than one test, It should be placed to run for every test.

I prefered to place it in afterEach, in case we don't need to place it in other suites.