### PR TITLE
Make emitted event kebab-case, to support using in-DOM templates

### DIFF
--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -36,7 +36,7 @@
                         :key="row.vueTableComponentInternalRowId"
                         :row="row"
                         :columns="columns"
-						@rowClick="emitRowClick"
+						@row-click="emitRowClick"
                 ></table-row>
                 </tbody>
                 <tfoot>
@@ -315,7 +315,7 @@
             },
 
 			emitRowClick(row) {
-				this.$emit('rowClick', row);
+				this.$emit('row-click', row);
 			}
         },
     };

--- a/src/components/TableComponent.vue
+++ b/src/components/TableComponent.vue
@@ -36,7 +36,7 @@
                         :key="row.vueTableComponentInternalRowId"
                         :row="row"
                         :columns="columns"
-						@row-click="emitRowClick"
+						@rowClick="emitRowClick"
                 ></table-row>
                 </tbody>
                 <tfoot>
@@ -315,6 +315,7 @@
             },
 
 			emitRowClick(row) {
+				this.$emit('rowClick', row);
 				this.$emit('row-click', row);
 			}
         },

--- a/src/components/TableRow.vue
+++ b/src/components/TableRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <tr @click="$emit('rowClick', row)">
+    <tr @click="$emit('row-click', row)">
         <table-cell
             v-for="column in visibleColumns"
             :row="row"

--- a/src/components/TableRow.vue
+++ b/src/components/TableRow.vue
@@ -1,5 +1,5 @@
 <template>
-    <tr @click="$emit('row-click', row)">
+    <tr @click="$emit('rowClick', row)">
         <table-cell
             v-for="column in visibleColumns"
             :row="row"


### PR DESCRIPTION
HTML attributes are case-insensitive and you cannot use v-on to listen to camelCase events when using in-DOM templates. 

We should use "row-click" instead of "rowClick".

[vuejs/vue#5186 (comment)](https://github.com/vuejs/vue/issues/5186#issuecomment-286304512)